### PR TITLE
Remove call chaining.

### DIFF
--- a/lib/src/vector_math/aabb2.dart
+++ b/lib/src/vector_math/aabb2.dart
@@ -76,7 +76,7 @@ class Aabb2 {
   }
 
   /// Transform [this] by the transform [t].
-  Aabb2 transform(Matrix3 t) {
+  void transform(Matrix3 t) {
     final center = new Vector2.zero();
     final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -89,11 +89,10 @@ class Aabb2 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Rotate [this] by the rotation matrix [t].
-  Aabb2 rotate(Matrix3 t) {
+  void rotate(Matrix3 t) {
     final center = new Vector2.zero();
     final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -104,7 +103,6 @@ class Aabb2 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Create a copy of [this] that is transformed by the transform [t] and store

--- a/lib/src/vector_math/aabb3.dart
+++ b/lib/src/vector_math/aabb3.dart
@@ -195,7 +195,7 @@ class Aabb3 {
   }
 
   /// Transform [this] by the transform [t].
-  Aabb3 transform(Matrix4 t) {
+  void transform(Matrix4 t) {
     final center = new Vector3.zero();
     final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -208,11 +208,10 @@ class Aabb3 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Rotate [this] by the rotation matrix [t].
-  Aabb3 rotate(Matrix4 t) {
+  void rotate(Matrix4 t) {
     final center = new Vector3.zero();
     final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -223,7 +222,6 @@ class Aabb3 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Create a copy of [this] that is transformed by the transform [t] and store

--- a/lib/src/vector_math/constants.dart
+++ b/lib/src/vector_math/constants.dart
@@ -8,4 +8,3 @@ part of vector_math;
 const double degrees2Radians = Math.PI / 180.0;
 /// Constant factor to convert and angle from radians to degrees.
 const double radians2Degrees = 180.0 / Math.PI;
-

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -75,59 +75,53 @@ class Matrix2 {
       new Matrix2.zero()..setRotation(radians);
 
   /// Sets the matrix with specified values.
-  Matrix2 setValues(double arg0, double arg1, double arg2, double arg3) {
+  void setValues(double arg0, double arg1, double arg2, double arg3) {
     _m2storage[3] = arg3;
     _m2storage[2] = arg2;
     _m2storage[1] = arg1;
     _m2storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix2 setColumns(Vector2 arg0, Vector2 arg1) {
+  void setColumns(Vector2 arg0, Vector2 arg1) {
     final arg0Storage = arg0._v2storage;
     final arg1Storage = arg1._v2storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
     _m2storage[3] = arg1Storage[1];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix2 setFrom(Matrix2 arg) {
+  void setFrom(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m2storage[3] = argStorage[3];
     _m2storage[2] = argStorage[2];
     _m2storage[1] = argStorage[1];
     _m2storage[0] = argStorage[0];
-    return this;
   }
 
   /// Set [this] to the outer product of [u] and [v].
-  Matrix2 setOuter(Vector2 u, Vector2 v) {
+  void setOuter(Vector2 u, Vector2 v) {
     final uStorage = u._v2storage;
     final vStorage = v._v2storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
     _m2storage[3] = uStorage[1] * vStorage[1];
-    return this;
   }
 
   /// Sets the diagonal to [arg].
-  Matrix2 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m2storage[0] = arg;
     _m2storage[3] = arg;
-    return this;
   }
 
   /// Sets the diagonal of the matrix to be [arg].
-  Matrix2 setDiagonal(Vector2 arg) {
+  void setDiagonal(Vector2 arg) {
     final argStorage = arg._v2storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
-    return this;
   }
 
   /// Returns a printable string
@@ -225,31 +219,28 @@ class Matrix2 {
   Matrix2 operator -() => clone()..negate();
 
   /// Zeros [this].
-  Matrix2 setZero() {
+  void setZero() {
     _m2storage[0] = 0.0;
     _m2storage[1] = 0.0;
     _m2storage[2] = 0.0;
     _m2storage[3] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix2 setIdentity() {
+  void setIdentity() {
     _m2storage[0] = 1.0;
     _m2storage[1] = 0.0;
     _m2storage[2] = 0.0;
     _m2storage[3] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix2 transposed() => clone()..transpose();
 
-  Matrix2 transpose() {
+  void transpose() {
     double temp = _m2storage[2];
     _m2storage[2] = _m2storage[1];
     _m2storage[1] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -363,58 +354,53 @@ class Matrix2 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix2 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     double temp = _m2storage[0];
     _m2storage[0] = _m2storage[3] * scale;
     _m2storage[2] = -_m2storage[2] * scale;
     _m2storage[1] = -_m2storage[1] * scale;
     _m2storage[3] = temp * scale;
-    return this;
   }
 
   /// Scale [this] by [scale].
-  Matrix2 scale(double scale) {
+  void scale(double scale) {
     _m2storage[0] = _m2storage[0] * scale;
     _m2storage[1] = _m2storage[1] * scale;
     _m2storage[2] = _m2storage[2] * scale;
     _m2storage[3] = _m2storage[3] * scale;
-    return this;
   }
 
   /// Create a copy of [this] scaled by [scale].
   Matrix2 scaled(double scale) => clone()..scale(scale);
 
   /// Add [o] to [this].
-  Matrix2 add(Matrix2 o) {
+  void add(Matrix2 o) {
     final oStorage = o._m2storage;
     _m2storage[0] = _m2storage[0] + oStorage[0];
     _m2storage[1] = _m2storage[1] + oStorage[1];
     _m2storage[2] = _m2storage[2] + oStorage[2];
     _m2storage[3] = _m2storage[3] + oStorage[3];
-    return this;
   }
 
   /// Subtract [o] from [this].
-  Matrix2 sub(Matrix2 o) {
+  void sub(Matrix2 o) {
     final oStorage = o._m2storage;
     _m2storage[0] = _m2storage[0] - oStorage[0];
     _m2storage[1] = _m2storage[1] - oStorage[1];
     _m2storage[2] = _m2storage[2] - oStorage[2];
     _m2storage[3] = _m2storage[3] - oStorage[3];
-    return this;
   }
 
   /// Negate [this].
-  Matrix2 negate() {
+  void negate() {
     _m2storage[0] = -_m2storage[0];
     _m2storage[1] = -_m2storage[1];
     _m2storage[2] = -_m2storage[2];
     _m2storage[3] = -_m2storage[3];
-    return this;
   }
 
   /// Multiply [this] with [arg] and store it in [this].
-  Matrix2 multiply(Matrix2 arg) {
+  void multiply(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[2];
     final m10 = _m2storage[1];
@@ -428,14 +414,13 @@ class Matrix2 {
     _m2storage[2] = (m00 * n01) + (m01 * n11);
     _m2storage[1] = (m10 * n00) + (m11 * n10);
     _m2storage[3] = (m10 * n01) + (m11 * n11);
-    return this;
   }
 
   /// Multiply [this] with [arg] and return the product.
   Matrix2 multiplied(Matrix2 arg) => clone()..multiply(arg);
 
   /// Multiply a transposed [this] with [arg].
-  Matrix2 transposeMultiply(Matrix2 arg) {
+  void transposeMultiply(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[1];
     final m10 = _m2storage[2];
@@ -445,11 +430,10 @@ class Matrix2 {
     _m2storage[2] = (m00 * argStorage[2]) + (m01 * argStorage[3]);
     _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[1]);
     _m2storage[3] = (m10 * argStorage[2]) + (m11 * argStorage[3]);
-    return this;
   }
 
   /// Multiply [this] with a transposed [arg].
-  Matrix2 multiplyTranspose(Matrix2 arg) {
+  void multiplyTranspose(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[2];
     final m10 = _m2storage[1];
@@ -459,7 +443,6 @@ class Matrix2 {
     _m2storage[2] = (m00 * argStorage[1]) + (m01 * argStorage[3]);
     _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[2]);
     _m2storage[3] = (m10 * argStorage[1]) + (m11 * argStorage[3]);
-    return this;
   }
 
   /// Transform [arg] of type [Vector2] using the transformation defined by

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -132,7 +132,7 @@ class Matrix3 {
       new Matrix3.zero()..setRotationZ(radians);
 
   /// Sets the matrix with specified values.
-  Matrix3 setValues(double arg0, double arg1, double arg2, double arg3,
+  void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
     _m3storage[8] = arg8;
     _m3storage[7] = arg7;
@@ -143,11 +143,10 @@ class Matrix3 {
     _m3storage[2] = arg2;
     _m3storage[1] = arg1;
     _m3storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix3 setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
+  void setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
     final arg0Storage = arg0._v3storage;
     final arg1Storage = arg1._v3storage;
     final arg2Storage = arg2._v3storage;
@@ -160,11 +159,10 @@ class Matrix3 {
     _m3storage[6] = arg2Storage[0];
     _m3storage[7] = arg2Storage[1];
     _m3storage[8] = arg2Storage[2];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix3 setFrom(Matrix3 arg) {
+  void setFrom(Matrix3 arg) {
     final argStorage = arg._m3storage;
     _m3storage[8] = argStorage[8];
     _m3storage[7] = argStorage[7];
@@ -175,11 +173,10 @@ class Matrix3 {
     _m3storage[2] = argStorage[2];
     _m3storage[1] = argStorage[1];
     _m3storage[0] = argStorage[0];
-    return this;
   }
 
   /// Set [this] to the outer product of [u] and [v].
-  Matrix3 setOuter(Vector3 u, Vector3 v) {
+  void setOuter(Vector3 u, Vector3 v) {
     final uStorage = u._v3storage;
     final vStorage = v._v3storage;
     _m3storage[0] = uStorage[0] * vStorage[0];
@@ -191,33 +188,29 @@ class Matrix3 {
     _m3storage[6] = uStorage[2] * vStorage[0];
     _m3storage[7] = uStorage[2] * vStorage[1];
     _m3storage[8] = uStorage[2] * vStorage[2];
-    return this;
   }
 
   /// Set the diagonal of the matrix.
-  Matrix3 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m3storage[0] = arg;
     _m3storage[4] = arg;
     _m3storage[8] = arg;
-    return this;
   }
 
   /// Set the diagonal of the matrix.
-  Matrix3 setDiagonal(Vector3 arg) {
+  void setDiagonal(Vector3 arg) {
     _m3storage[0] = arg.storage[0];
     _m3storage[4] = arg.storage[1];
     _m3storage[8] = arg.storage[2];
-    return this;
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
-  Matrix3 setUpper2x2(Matrix2 arg) {
+  void setUpper2x2(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m3storage[0] = argStorage[0];
     _m3storage[1] = argStorage[1];
     _m3storage[3] = argStorage[2];
     _m3storage[4] = argStorage[3];
-    return this;
   }
 
   /// Returns a printable string
@@ -332,7 +325,7 @@ class Matrix3 {
   Matrix3 operator -() => clone()..negate();
 
   /// Zeros [this].
-  Matrix3 setZero() {
+  void setZero() {
     _m3storage[0] = 0.0;
     _m3storage[1] = 0.0;
     _m3storage[2] = 0.0;
@@ -342,11 +335,10 @@ class Matrix3 {
     _m3storage[6] = 0.0;
     _m3storage[7] = 0.0;
     _m3storage[8] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix3 setIdentity() {
+  void setIdentity() {
     _m3storage[0] = 1.0;
     _m3storage[1] = 0.0;
     _m3storage[2] = 0.0;
@@ -356,14 +348,13 @@ class Matrix3 {
     _m3storage[6] = 0.0;
     _m3storage[7] = 0.0;
     _m3storage[8] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix3 transposed() => clone()..transpose();
 
   /// Transpose [this].
-  Matrix3 transpose() {
+  void transpose() {
     double temp;
     temp = _m3storage[3];
     _m3storage[3] = _m3storage[1];
@@ -374,7 +365,6 @@ class Matrix3 {
     temp = _m3storage[7];
     _m3storage[7] = _m3storage[5];
     _m3storage[5] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -516,10 +506,9 @@ class Matrix3 {
   }
 
   /// Set this matrix to be the normal matrix of [arg].
-  Matrix3 copyNormalMatrix(Matrix4 arg) {
+  void copyNormalMatrix(Matrix4 arg) {
     copyInverse(arg.getRotation());
     transpose();
-    return this;
   }
 
   /// Turns the matrix into a rotation of [radians] around X
@@ -568,7 +557,7 @@ class Matrix3 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix3 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[3];
     double m02 = _m3storage[6];
@@ -587,7 +576,6 @@ class Matrix3 {
     _m3storage[6] = (m01 * m12 - m02 * m11) * scale;
     _m3storage[7] = (m02 * m10 - m00 * m12) * scale;
     _m3storage[8] = (m00 * m11 - m01 * m10) * scale;
-    return this;
   }
 
   /// Rotates [arg] by the absolute rotation of [this]
@@ -660,7 +648,7 @@ class Matrix3 {
   Matrix3 scaled(double scale) => clone()..scale(scale);
 
   /// Add [o] to [this].
-  Matrix3 add(Matrix3 o) {
+  void add(Matrix3 o) {
     final oStorage = o._m3storage;
     _m3storage[0] = _m3storage[0] + oStorage[0];
     _m3storage[1] = _m3storage[1] + oStorage[1];
@@ -671,11 +659,10 @@ class Matrix3 {
     _m3storage[6] = _m3storage[6] + oStorage[6];
     _m3storage[7] = _m3storage[7] + oStorage[7];
     _m3storage[8] = _m3storage[8] + oStorage[8];
-    return this;
   }
 
   /// Subtract [o] from [this].
-  Matrix3 sub(Matrix3 o) {
+  void sub(Matrix3 o) {
     final oStorage = o._m3storage;
     _m3storage[0] = _m3storage[0] - oStorage[0];
     _m3storage[1] = _m3storage[1] - oStorage[1];
@@ -686,11 +673,10 @@ class Matrix3 {
     _m3storage[6] = _m3storage[6] - oStorage[6];
     _m3storage[7] = _m3storage[7] - oStorage[7];
     _m3storage[8] = _m3storage[8] - oStorage[8];
-    return this;
   }
 
   /// Negate [this].
-  Matrix3 negate() {
+  void negate() {
     _m3storage[0] = -_m3storage[0];
     _m3storage[1] = -_m3storage[1];
     _m3storage[2] = -_m3storage[2];
@@ -700,11 +686,10 @@ class Matrix3 {
     _m3storage[6] = -_m3storage[6];
     _m3storage[7] = -_m3storage[7];
     _m3storage[8] = -_m3storage[8];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Matrix3 multiply(Matrix3 arg) {
+  void multiply(Matrix3 arg) {
     final double m00 = _m3storage[0];
     final double m01 = _m3storage[3];
     final double m02 = _m3storage[6];
@@ -733,13 +718,12 @@ class Matrix3 {
     _m3storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
     _m3storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
     _m3storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
-    return this;
   }
 
   /// Create a copy of [this] and multiply it by [arg].
   Matrix3 multiplied(Matrix3 arg) => clone()..multiply(arg);
 
-  Matrix3 transposeMultiply(Matrix3 arg) {
+  void transposeMultiply(Matrix3 arg) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[1];
     double m02 = _m3storage[2];
@@ -768,10 +752,9 @@ class Matrix3 {
         (m20 * argStorage[3]) + (m21 * arg.storage[4]) + (m22 * arg.storage[5]);
     _m3storage[8] =
         (m20 * argStorage[6]) + (m21 * arg.storage[7]) + (m22 * arg.storage[8]);
-    return this;
   }
 
-  Matrix3 multiplyTranspose(Matrix3 arg) {
+  void multiplyTranspose(Matrix3 arg) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[3];
     double m02 = _m3storage[6];
@@ -800,7 +783,6 @@ class Matrix3 {
         (m20 * argStorage[1]) + (m21 * argStorage[4]) + (m22 * argStorage[7]);
     _m3storage[8] =
         (m20 * argStorage[2]) + (m21 * argStorage[5]) + (m22 * argStorage[8]);
-    return this;
   }
 
   /// Transform [arg] of type [Vector3] using the transformation defined by

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -254,16 +254,15 @@ class Matrix4 {
     ..setFromTranslationRotationScale(translation, rotation, scale);
 
   /// Sets the diagonal to [arg].
-  Matrix4 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m4storage[0] = arg;
     _m4storage[5] = arg;
     _m4storage[10] = arg;
     _m4storage[15] = arg;
-    return this;
   }
 
   /// Sets the matrix with specified values.
-  Matrix4 setValues(double arg0, double arg1, double arg2, double arg3,
+  void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8,
       double arg9, double arg10, double arg11, double arg12, double arg13,
       double arg14, double arg15) {
@@ -283,11 +282,10 @@ class Matrix4 {
     _m4storage[2] = arg2;
     _m4storage[1] = arg1;
     _m4storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix4 setColumns(Vector4 arg0, Vector4 arg1, Vector4 arg2, Vector4 arg3) {
+  void setColumns(Vector4 arg0, Vector4 arg1, Vector4 arg2, Vector4 arg3) {
     final arg0Storage = arg0._v4storage;
     final arg1Storage = arg1._v4storage;
     final arg2Storage = arg2._v4storage;
@@ -308,11 +306,10 @@ class Matrix4 {
     _m4storage[13] = arg3Storage[1];
     _m4storage[14] = arg3Storage[2];
     _m4storage[15] = arg3Storage[3];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix4 setFrom(Matrix4 arg) {
+  void setFrom(Matrix4 arg) {
     final argStorage = arg._m4storage;
     _m4storage[15] = argStorage[15];
     _m4storage[14] = argStorage[14];
@@ -330,11 +327,10 @@ class Matrix4 {
     _m4storage[2] = argStorage[2];
     _m4storage[1] = argStorage[1];
     _m4storage[0] = argStorage[0];
-    return this;
   }
 
   /// Sets the matrix from translation [arg0] and rotation [arg1].
-  Matrix4 setFromTranslationRotation(Vector3 arg0, Quaternion arg1) {
+  void setFromTranslationRotation(Vector3 arg0, Quaternion arg1) {
     final arg1Storage = arg1._qStorage;
     double x = arg1Storage[0];
     double y = arg1Storage[1];
@@ -370,35 +366,31 @@ class Matrix4 {
     _m4storage[13] = arg0Storage[1];
     _m4storage[14] = arg0Storage[2];
     _m4storage[15] = 1.0;
-    return this;
   }
 
   /// Sets the matrix from [translation], [rotation] and [scale].
-  Matrix4 setFromTranslationRotationScale(
+  void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
     this.scale(scale);
-    return this;
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
-  Matrix4 setUpper2x2(Matrix2 arg) {
+  void setUpper2x2(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m4storage[0] = argStorage[0];
     _m4storage[1] = argStorage[1];
     _m4storage[4] = argStorage[2];
     _m4storage[5] = argStorage[3];
-    return this;
   }
 
   /// Sets the diagonal of the matrix to be [arg].
-  Matrix4 setDiagonal(Vector4 arg) {
+  void setDiagonal(Vector4 arg) {
     final argStorage = arg._v4storage;
     _m4storage[0] = argStorage[0];
     _m4storage[5] = argStorage[1];
     _m4storage[10] = argStorage[2];
     _m4storage[15] = argStorage[3];
-    return this;
   }
 
   void setOuter(Vector4 u, Vector4 v) {
@@ -553,7 +545,7 @@ class Matrix4 {
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
   /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
-  Matrix4 translate(x, [double y = 0.0, double z = 0.0]) {
+  void translate(x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
     double tz;
@@ -587,11 +579,10 @@ class Matrix4 {
     _m4storage[13] = t2;
     _m4storage[14] = t3;
     _m4storage[15] = t4;
-    return this;
   }
 
   /// Rotate this [angle] radians around [axis]
-  Matrix4 rotate(Vector3 axis, double angle) {
+  void rotate(Vector3 axis, double angle) {
     var len = axis.length;
     final axisStorage = axis._v3storage;
     var x = axisStorage[0] / len;
@@ -633,11 +624,10 @@ class Matrix4 {
     _m4storage[9] = t10;
     _m4storage[10] = t11;
     _m4storage[11] = t12;
-    return this;
   }
 
   /// Rotate this [angle] radians around X
-  Matrix4 rotateX(double angle) {
+  void rotateX(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[4] * cosAngle + _m4storage[8] * sinAngle;
@@ -656,11 +646,10 @@ class Matrix4 {
     _m4storage[9] = t6;
     _m4storage[10] = t7;
     _m4storage[11] = t8;
-    return this;
   }
 
   /// Rotate this matrix [angle] radians around Y
-  Matrix4 rotateY(double angle) {
+  void rotateY(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[0] * cosAngle + _m4storage[8] * -sinAngle;
@@ -679,11 +668,10 @@ class Matrix4 {
     _m4storage[9] = t6;
     _m4storage[10] = t7;
     _m4storage[11] = t8;
-    return this;
   }
 
   /// Rotate this matrix [angle] radians around Z
-  Matrix4 rotateZ(double angle) {
+  void rotateZ(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[0] * cosAngle + _m4storage[4] * sinAngle;
@@ -702,11 +690,10 @@ class Matrix4 {
     _m4storage[5] = t6;
     _m4storage[6] = t7;
     _m4storage[7] = t8;
-    return this;
   }
 
   /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
-  Matrix4 scale(x, [double y, double z]) {
+  void scale(x, [double y, double z]) {
     double sx;
     double sy;
     double sz;
@@ -736,7 +723,6 @@ class Matrix4 {
     _m4storage[13] *= sw;
     _m4storage[14] *= sw;
     _m4storage[15] *= sw;
-    return this;
   }
 
   /// Create a copy of [this] scaled by a [Vector3], [Vector4] or [x],[y], and
@@ -745,7 +731,7 @@ class Matrix4 {
       clone()..scale(x, y, z);
 
   /// Zeros [this].
-  Matrix4 setZero() {
+  void setZero() {
     _m4storage[0] = 0.0;
     _m4storage[1] = 0.0;
     _m4storage[2] = 0.0;
@@ -762,11 +748,10 @@ class Matrix4 {
     _m4storage[13] = 0.0;
     _m4storage[14] = 0.0;
     _m4storage[15] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix4 setIdentity() {
+  void setIdentity() {
     _m4storage[0] = 1.0;
     _m4storage[1] = 0.0;
     _m4storage[2] = 0.0;
@@ -783,13 +768,12 @@ class Matrix4 {
     _m4storage[13] = 0.0;
     _m4storage[14] = 0.0;
     _m4storage[15] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix4 transposed() => clone()..transpose();
 
-  Matrix4 transpose() {
+  void transpose() {
     double temp;
     temp = _m4storage[4];
     _m4storage[4] = _m4storage[1];
@@ -809,7 +793,6 @@ class Matrix4 {
     temp = _m4storage[14];
     _m4storage[14] = _m4storage[11];
     _m4storage[11] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -837,12 +820,18 @@ class Matrix4 {
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    double det2_01_01 = _m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4];
-    double det2_01_02 = _m4storage[0] * _m4storage[6] - _m4storage[2] * _m4storage[4];
-    double det2_01_03 = _m4storage[0] * _m4storage[7] - _m4storage[3] * _m4storage[4];
-    double det2_01_12 = _m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5];
-    double det2_01_13 = _m4storage[1] * _m4storage[7] - _m4storage[3] * _m4storage[5];
-    double det2_01_23 = _m4storage[2] * _m4storage[7] - _m4storage[3] * _m4storage[6];
+    double det2_01_01 =
+        _m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4];
+    double det2_01_02 =
+        _m4storage[0] * _m4storage[6] - _m4storage[2] * _m4storage[4];
+    double det2_01_03 =
+        _m4storage[0] * _m4storage[7] - _m4storage[3] * _m4storage[4];
+    double det2_01_12 =
+        _m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5];
+    double det2_01_13 =
+        _m4storage[1] * _m4storage[7] - _m4storage[3] * _m4storage[5];
+    double det2_01_23 =
+        _m4storage[2] * _m4storage[7] - _m4storage[3] * _m4storage[6];
     double det3_201_012 = _m4storage[8] * det2_01_12 -
         _m4storage[9] * det2_01_02 +
         _m4storage[10] * det2_01_01;
@@ -1025,7 +1014,7 @@ class Matrix4 {
   }
 
   /// Transposes just the upper 3x3 rotation matrix.
-  Matrix4 transposeRotation() {
+  void transposeRotation() {
     double temp;
     temp = _m4storage[1];
     _m4storage[1] = _m4storage[4];
@@ -1045,7 +1034,6 @@ class Matrix4 {
     temp = _m4storage[9];
     _m4storage[9] = _m4storage[6];
     _m4storage[6] = temp;
-    return this;
   }
 
   /// Invert [this].
@@ -1123,15 +1111,24 @@ class Matrix4 {
     double kx;
     double ky;
     double kz;
-    ix = invDet * (_m4storage[5] * _m4storage[10] - _m4storage[6] * _m4storage[9]);
-    iy = invDet * (_m4storage[2] * _m4storage[9] - _m4storage[1] * _m4storage[10]);
-    iz = invDet * (_m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5]);
-    jx = invDet * (_m4storage[6] * _m4storage[8] - _m4storage[4] * _m4storage[10]);
-    jy = invDet * (_m4storage[0] * _m4storage[10] - _m4storage[2] * _m4storage[8]);
-    jz = invDet * (_m4storage[2] * _m4storage[4] - _m4storage[0] * _m4storage[6]);
-    kx = invDet * (_m4storage[4] * _m4storage[9] - _m4storage[5] * _m4storage[8]);
-    ky = invDet * (_m4storage[1] * _m4storage[8] - _m4storage[0] * _m4storage[9]);
-    kz = invDet * (_m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4]);
+    ix = invDet *
+        (_m4storage[5] * _m4storage[10] - _m4storage[6] * _m4storage[9]);
+    iy = invDet *
+        (_m4storage[2] * _m4storage[9] - _m4storage[1] * _m4storage[10]);
+    iz = invDet *
+        (_m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5]);
+    jx = invDet *
+        (_m4storage[6] * _m4storage[8] - _m4storage[4] * _m4storage[10]);
+    jy = invDet *
+        (_m4storage[0] * _m4storage[10] - _m4storage[2] * _m4storage[8]);
+    jz = invDet *
+        (_m4storage[2] * _m4storage[4] - _m4storage[0] * _m4storage[6]);
+    kx = invDet *
+        (_m4storage[4] * _m4storage[9] - _m4storage[5] * _m4storage[8]);
+    ky = invDet *
+        (_m4storage[1] * _m4storage[8] - _m4storage[0] * _m4storage[9]);
+    kz = invDet *
+        (_m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4]);
     _m4storage[0] = ix;
     _m4storage[1] = iy;
     _m4storage[2] = iz;
@@ -1199,7 +1196,7 @@ class Matrix4 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix4 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     // Adapted from code by Richard Carling.
     double a1 = _m4storage[0];
     double b1 = _m4storage[4];
@@ -1281,7 +1278,6 @@ class Matrix4 {
             b1 * (a2 * c3 - a3 * c2) +
             c1 * (a2 * b3 - a3 * b2)) *
         scale;
-    return this;
   }
 
   /// Rotates [arg] by the absolute rotation of [this]
@@ -1308,7 +1304,7 @@ class Matrix4 {
   }
 
   /// Adds [o] to [this].
-  Matrix4 add(Matrix4 o) {
+  void add(Matrix4 o) {
     final oStorage = o._m4storage;
     _m4storage[0] = _m4storage[0] + oStorage[0];
     _m4storage[1] = _m4storage[1] + oStorage[1];
@@ -1326,11 +1322,10 @@ class Matrix4 {
     _m4storage[13] = _m4storage[13] + oStorage[13];
     _m4storage[14] = _m4storage[14] + oStorage[14];
     _m4storage[15] = _m4storage[15] + oStorage[15];
-    return this;
   }
 
   /// Subtracts [o] from [this].
-  Matrix4 sub(Matrix4 o) {
+  void sub(Matrix4 o) {
     final oStorage = o._m4storage;
     _m4storage[0] = _m4storage[0] - oStorage[0];
     _m4storage[1] = _m4storage[1] - oStorage[1];
@@ -1348,11 +1343,10 @@ class Matrix4 {
     _m4storage[13] = _m4storage[13] - oStorage[13];
     _m4storage[14] = _m4storage[14] - oStorage[14];
     _m4storage[15] = _m4storage[15] - oStorage[15];
-    return this;
   }
 
   /// Negate [this].
-  Matrix4 negate() {
+  void negate() {
     _m4storage[0] = -_m4storage[0];
     _m4storage[1] = -_m4storage[1];
     _m4storage[2] = -_m4storage[2];
@@ -1369,11 +1363,10 @@ class Matrix4 {
     _m4storage[13] = -_m4storage[13];
     _m4storage[14] = -_m4storage[14];
     _m4storage[15] = -_m4storage[15];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Matrix4 multiply(Matrix4 arg) {
+  void multiply(Matrix4 arg) {
     final m00 = _m4storage[0];
     final m01 = _m4storage[4];
     final m02 = _m4storage[8];
@@ -1423,14 +1416,13 @@ class Matrix4 {
     _m4storage[7] = (m30 * n01) + (m31 * n11) + (m32 * n21) + (m33 * n31);
     _m4storage[11] = (m30 * n02) + (m31 * n12) + (m32 * n22) + (m33 * n32);
     _m4storage[15] = (m30 * n03) + (m31 * n13) + (m32 * n23) + (m33 * n33);
-    return this;
   }
 
   /// Multiply a copy of [this] with [arg].
   Matrix4 multiplied(Matrix4 arg) => clone()..multiply(arg);
 
   /// Multiply a transposed [this] with [arg].
-  Matrix4 transposeMultiply(Matrix4 arg) {
+  void transposeMultiply(Matrix4 arg) {
     double m00 = _m4storage[0];
     double m01 = _m4storage[1];
     double m02 = _m4storage[2];
@@ -1512,11 +1504,10 @@ class Matrix4 {
         (m31 * argStorage[13]) +
         (m32 * argStorage[14]) +
         (m33 * argStorage[15]);
-    return this;
   }
 
   /// Multiply [this] with a transposed [arg].
-  Matrix4 multiplyTranspose(Matrix4 arg) {
+  void multiplyTranspose(Matrix4 arg) {
     double m00 = _m4storage[0];
     double m01 = _m4storage[4];
     double m02 = _m4storage[8];
@@ -1598,20 +1589,21 @@ class Matrix4 {
         (m31 * argStorage[7]) +
         (m32 * argStorage[11]) +
         (m33 * argStorage[15]);
-    return this;
   }
+
   /// Decomposes [this] into [translation], [rotation] and [scale] components.
   void decompose(Vector3 translation, Quaternion rotation, Vector3 scale) {
     final v = new Vector3.zero();
-    var sx = v.setValues(_m4storage[0], _m4storage[1], _m4storage[2]).length;
-    var sy = v.setValues(_m4storage[4], _m4storage[5], _m4storage[6]).length;
-    var sz = v.setValues(_m4storage[8], _m4storage[9], _m4storage[10]).length;
+    var sx = (v..setValues(_m4storage[0], _m4storage[1], _m4storage[2])).length;
+    var sy = (v..setValues(_m4storage[4], _m4storage[5], _m4storage[6])).length;
+    var sz = (v
+      ..setValues(_m4storage[8], _m4storage[9], _m4storage[10])).length;
 
     if (determinant() < 0) sx = -sx;
 
-    translation.storage[0] = _m4storage[12];
-    translation.storage[1] = _m4storage[13];
-    translation.storage[2] = _m4storage[14];
+    translation._v3storage[0] = _m4storage[12];
+    translation._v3storage[1] = _m4storage[13];
+    translation._v3storage[2] = _m4storage[14];
 
     final invSX = 1.0 / sx;
     final invSY = 1.0 / sy;
@@ -1630,9 +1622,9 @@ class Matrix4 {
 
     rotation.setFromRotation(m.getRotation());
 
-    scale.storage[0] = sx;
-    scale.storage[1] = sy;
-    scale.storage[2] = sz;
+    scale._v3storage[0] = sx;
+    scale._v3storage[1] = sy;
+    scale._v3storage[2] = sz;
   }
 
   /// Rotate [arg] of type [Vector3] using the rotation defined by [this].

--- a/lib/src/vector_math/obb3.dart
+++ b/lib/src/vector_math/obb3.dart
@@ -84,9 +84,9 @@ class Obb3 {
     t.transform(_axis0..scale(_halfExtents.x));
     t.transform(_axis1..scale(_halfExtents.y));
     t.transform(_axis2..scale(_halfExtents.z));
-    _halfExtents.x = _axis0.normalizeLength();
-    _halfExtents.y = _axis1.normalizeLength();
-    _halfExtents.z = _axis2.normalizeLength();
+    _halfExtents.x = _axis0.normalize();
+    _halfExtents.y = _axis1.normalize();
+    _halfExtents.z = _axis2.normalize();
   }
 
   /// Transform [this] by the transform [t].
@@ -95,9 +95,9 @@ class Obb3 {
     t.rotate3(_axis0..scale(_halfExtents.x));
     t.rotate3(_axis1..scale(_halfExtents.y));
     t.rotate3(_axis2..scale(_halfExtents.z));
-    _halfExtents.x = _axis0.normalizeLength();
-    _halfExtents.y = _axis1.normalizeLength();
-    _halfExtents.z = _axis2.normalizeLength();
+    _halfExtents.x = _axis0.normalize();
+    _halfExtents.y = _axis1.normalize();
+    _halfExtents.z = _axis2.normalize();
   }
 
   /// Store the corner with [cornerIndex] in [corner].

--- a/lib/src/vector_math/opengl.dart
+++ b/lib/src/vector_math/opengl.dart
@@ -56,7 +56,7 @@ void setRotationMatrix(
 /// [tx],[ty],[tz] specifies the position of the object.
 void setModelMatrix(Matrix4 modelMatrix, Vector3 forwardDirection,
     Vector3 upDirection, double tx, double ty, double tz) {
-  Vector3 right = forwardDirection.cross(upDirection).normalize();
+  Vector3 right = forwardDirection.cross(upDirection)..normalize();
   Vector3 c1 = right;
   Vector3 c2 = upDirection;
   Vector3 c3 = -forwardDirection;
@@ -150,7 +150,7 @@ void setFrustumMatrix(Matrix4 perspectiveMatrix, double left, double right,
   double right_minus_left = right - left;
   double top_minus_bottom = top - bottom;
   double far_minus_near = far - near;
-  Matrix4 view = perspectiveMatrix.setZero();
+  Matrix4 view = perspectiveMatrix..setZero();
   view.setEntry(0, 0, two_near / right_minus_left);
   view.setEntry(1, 1, two_near / top_minus_bottom);
   view.setEntry(0, 2, (right + left) / right_minus_left);
@@ -191,7 +191,7 @@ void setOrthographicMatrix(Matrix4 orthographicMatrix, double left,
   double tpb = top + bottom;
   double fmn = far - near;
   double fpn = far + near;
-  Matrix4 r = orthographicMatrix.setZero();
+  Matrix4 r = orthographicMatrix..setZero();
   r.setEntry(0, 0, 2.0 / rml);
   r.setEntry(1, 1, 2.0 / tmb);
   r.setEntry(2, 2, -2.0 / fmn);

--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -210,35 +210,33 @@ class Quaternion {
   }
 
   /// Normalize [this].
-  Quaternion normalize() {
-    var l = length;
+  double normalize() {
+    double l = length;
     if (l == 0.0) {
-      return this;
+      return 0.0;
     }
-    l = 1.0 / l;
-    _qStorage[3] = _qStorage[3] * l;
-    _qStorage[2] = _qStorage[2] * l;
-    _qStorage[1] = _qStorage[1] * l;
-    _qStorage[0] = _qStorage[0] * l;
-    return this;
+    var d = 1.0 / l;
+    _qStorage[0] *= d;
+    _qStorage[1] *= d;
+    _qStorage[2] *= d;
+    _qStorage[3] *= d;
+    return l;
   }
 
   /// Conjugate [this].
-  Quaternion conjugate() {
+  void conjugate() {
     _qStorage[2] = -_qStorage[2];
     _qStorage[1] = -_qStorage[1];
     _qStorage[0] = -_qStorage[0];
-    return this;
   }
 
   /// Invert [this].
-  Quaternion inverse() {
+  void inverse() {
     final l = 1.0 / length2;
     _qStorage[3] = _qStorage[3] * l;
     _qStorage[2] = -_qStorage[2] * l;
     _qStorage[1] = -_qStorage[1] * l;
     _qStorage[0] = -_qStorage[0] * l;
-    return this;
   }
 
   /// Normalized copy of [this].

--- a/lib/src/vector_math/vector.dart
+++ b/lib/src/vector_math/vector.dart
@@ -16,9 +16,7 @@ void cross3(Vector3 x, Vector3 y, Vector3 out) {
 }
 
 /// 2D cross product. vec2 x vec2.
-double cross2(Vector2 x, Vector2 y) {
-  return x.cross(y);
-}
+double cross2(Vector2 x, Vector2 y) => x.cross(y);
 
 /// 2D cross product. double x vec2.
 void cross2A(double x, Vector2 y, Vector2 out) {

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -55,32 +55,28 @@ class Vector2 implements Vector {
       : _v2storage = new Float32List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
-  Vector2 setValues(double x_, double y_) {
+  void setValues(double x_, double y_) {
     _v2storage[0] = x_;
     _v2storage[1] = y_;
-    return this;
   }
 
   /// Zero the vector.
-  Vector2 setZero() {
+  void setZero() {
     _v2storage[0] = 0.0;
     _v2storage[1] = 0.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector2 setFrom(Vector2 other) {
+  void setFrom(Vector2 other) {
     final otherStorage = other._v2storage;
     _v2storage[1] = otherStorage[1];
     _v2storage[0] = otherStorage[0];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector2 splat(double arg) {
+  void splat(double arg) {
     _v2storage[0] = arg;
     _v2storage[1] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -143,20 +139,7 @@ class Vector2 implements Vector {
   }
 
   /// Normalize [this].
-  Vector2 normalize() {
-    double l = length;
-    // TODO(johnmccutchan): Use an epsilon.
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v2storage[0] *= l;
-    _v2storage[1] *= l;
-    return this;
-  }
-
-  /// Normalize [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -167,13 +150,20 @@ class Vector2 implements Vector {
     return l;
   }
 
+  /// Normalize [this]. Returns length of vector before normalization.
+  /// /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalized copy of [this].
   Vector2 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector2 normalizeInto(Vector2 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -202,14 +192,12 @@ class Vector2 implements Vector {
    * If [arg] is a rotation matrix, this is a computational shortcut for applying,
    * the inverse of the transformation.
    */
-  Vector2 postmultiply(Matrix2 arg) {
+  void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
     double v0 = _v2storage[0];
     double v1 = _v2storage[1];
     _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
     _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
-
-    return this;
   }
 
   /// Cross product.
@@ -225,9 +213,8 @@ class Vector2 implements Vector {
   }
 
   /// Reflect [this].
-  Vector2 reflect(Vector2 normal) {
+  void reflect(Vector2 normal) {
     sub(normal.scaled(2.0 * normal.dot(this)));
-    return this;
   }
 
   /// Reflected copy of [this].
@@ -262,115 +249,101 @@ class Vector2 implements Vector {
   }
 
   /// Add [arg] to [this].
-  Vector2 add(Vector2 arg) {
+  void add(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] + argStorage[0];
     _v2storage[1] = _v2storage[1] + argStorage[1];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector2 addScaled(Vector2 arg, double factor) {
+  void addScaled(Vector2 arg, double factor) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
     _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector2 sub(Vector2 arg) {
+  void sub(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] - argStorage[0];
     _v2storage[1] = _v2storage[1] - argStorage[1];
-    return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
-  Vector2 multiply(Vector2 arg) {
+  void multiply(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] * argStorage[0];
     _v2storage[1] = _v2storage[1] * argStorage[1];
-    return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
-  Vector2 divide(Vector2 arg) {
+  void divide(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] / argStorage[0];
     _v2storage[1] = _v2storage[1] / argStorage[1];
-    return this;
   }
 
   /// Scale [this] by [arg].
-  Vector2 scale(double arg) {
+  void scale(double arg) {
     _v2storage[1] = _v2storage[1] * arg;
     _v2storage[0] = _v2storage[0] * arg;
-    return this;
   }
 
   /// Return a copy of [this] scaled by [arg].
   Vector2 scaled(double arg) => clone()..scale(arg);
 
   /// Negate.
-  Vector2 negate() {
+  void negate() {
     _v2storage[1] = -_v2storage[1];
     _v2storage[0] = -_v2storage[0];
-    return this;
   }
 
   /// Absolute value.
-  Vector2 absolute() {
+  void absolute() {
     _v2storage[1] = _v2storage[1].abs();
     _v2storage[0] = _v2storage[0].abs();
-    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector2 clamp(Vector2 min, Vector2 max) {
+  void clamp(Vector2 min, Vector2 max) {
     var minStorage = min.storage;
     var maxStorage = max.storage;
     _v2storage[0] = _v2storage[0].clamp(minStorage[0], maxStorage[0]);
     _v2storage[1] = _v2storage[1].clamp(minStorage[1], maxStorage[1]);
-    return this;
   }
 
   /// Clamp entries [this] in the range [min]-[max].
-  Vector2 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v2storage[0] = _v2storage[0].clamp(min, max);
     _v2storage[1] = _v2storage[1].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector2 floor() {
+  void floor() {
     _v2storage[0] = _v2storage[0].floorToDouble();
     _v2storage[1] = _v2storage[1].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector2 ceil() {
+  void ceil() {
     _v2storage[0] = _v2storage[0].ceilToDouble();
     _v2storage[1] = _v2storage[1].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector2 round() {
+  void round() {
     _v2storage[0] = _v2storage[0].roundToDouble();
     _v2storage[1] = _v2storage[1].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector2 roundToZero() {
+  void roundToZero() {
     _v2storage[0] = _v2storage[0] < 0.0
         ? _v2storage[0].ceilToDouble()
         : _v2storage[0].floorToDouble();
     _v2storage[1] = _v2storage[1] < 0.0
         ? _v2storage[1].ceilToDouble()
         : _v2storage[1].floorToDouble();
-    return this;
   }
 
   /// Clone of [this].

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -59,36 +59,32 @@ class Vector3 implements Vector {
       : _v3storage = new Float32List.view(buffer, offset, 3);
 
   /// Set the values of the vector.
-  Vector3 setValues(double x_, double y_, double z_) {
+  void setValues(double x_, double y_, double z_) {
     _v3storage[0] = x_;
     _v3storage[1] = y_;
     _v3storage[2] = z_;
-    return this;
   }
 
   /// Zero vector.
-  Vector3 setZero() {
+  void setZero() {
     _v3storage[2] = 0.0;
     _v3storage[1] = 0.0;
     _v3storage[0] = 0.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector3 setFrom(Vector3 other) {
+  void setFrom(Vector3 other) {
     final otherStorage = other._v3storage;
     _v3storage[0] = otherStorage[0];
     _v3storage[1] = otherStorage[1];
     _v3storage[2] = otherStorage[2];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector3 splat(double arg) {
+  void splat(double arg) {
     _v3storage[2] = arg;
     _v3storage[1] = arg;
     _v3storage[0] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -154,20 +150,7 @@ class Vector3 implements Vector {
   }
 
   /// Normalizes [this].
-  Vector3 normalize() {
-    double l = length;
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v3storage[0] *= l;
-    _v3storage[1] *= l;
-    _v3storage[2] *= l;
-    return this;
-  }
-
-  /// Normalize [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -179,13 +162,20 @@ class Vector3 implements Vector {
     return l;
   }
 
+  /// Normalize [this]. Returns length of vector before normalization.
+  /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalizes copy of [this].
   Vector3 normalized() => new Vector3.copy(this)..normalize();
 
   /// Normalize vector into [out].
   Vector3 normalizeInto(Vector3 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -241,16 +231,18 @@ class Vector3 implements Vector {
    * If [arg] is a rotation matrix, this is a computational shortcut for applying,
    * the inverse of the transformation.
    */
-  Vector3 postmultiply(Matrix3 arg) {
+  void postmultiply(Matrix3 arg) {
     final argStorage = arg.storage;
     final v0 = _v3storage[0];
     final v1 = _v3storage[1];
     final v2 = _v3storage[2];
 
-    _v3storage[0] = v0 * argStorage[0] + v1 * argStorage[1] + v2 * argStorage[2];
-    _v3storage[1] = v0 * argStorage[3] + v1 * argStorage[4] + v2 * argStorage[5];
-    _v3storage[2] = v0 * argStorage[6] + v1 * argStorage[7] + v2 * argStorage[8];
-    return this;
+    _v3storage[0] =
+        v0 * argStorage[0] + v1 * argStorage[1] + v2 * argStorage[2];
+    _v3storage[1] =
+        v0 * argStorage[3] + v1 * argStorage[4] + v2 * argStorage[5];
+    _v3storage[2] =
+        v0 * argStorage[6] + v1 * argStorage[7] + v2 * argStorage[8];
   }
 
   /// Cross product.
@@ -282,16 +274,15 @@ class Vector3 implements Vector {
   }
 
   /// Reflect [this].
-  Vector3 reflect(Vector3 normal) {
+  void reflect(Vector3 normal) {
     sub(normal.scaled(2.0 * normal.dot(this)));
-    return this;
   }
 
   /// Reflected copy of [this].
   Vector3 reflected(Vector3 normal) => clone()..reflect(normal);
 
   /// Projects [this] using the projection matrix [arg]
-  Vector3 applyProjection(Matrix4 arg) {
+  void applyProjection(Matrix4 arg) {
     final argStorage = arg.storage;
     final x = _v3storage[0];
     final y = _v3storage[1];
@@ -316,17 +307,15 @@ class Vector3 implements Vector {
             argStorage[10] * z +
             argStorage[14]) *
         d;
-    return this;
   }
 
   /// Applies a rotation specified by [axis] and [angle].
-  Vector3 applyAxisAngle(Vector3 axis, double angle) {
+  void applyAxisAngle(Vector3 axis, double angle) {
     applyQuaternion(new Quaternion.axisAngle(axis, angle));
-    return this;
   }
 
   /// Applies a quaternion transform.
-  Vector3 applyQuaternion(Quaternion arg) {
+  void applyQuaternion(Quaternion arg) {
     final argStorage = arg._qStorage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
@@ -342,24 +331,25 @@ class Vector3 implements Vector {
     _v3storage[0] = ix * qw + iw * -qx + iy * -qz - iz * -qy;
     _v3storage[1] = iy * qw + iw * -qy + iz * -qx - ix * -qz;
     _v3storage[2] = iz * qw + iw * -qz + ix * -qy - iy * -qx;
-    return this;
   }
 
   /// Multiplies [this] by [arg].
-  Vector3 applyMatrix3(Matrix3 arg) {
+  void applyMatrix3(Matrix3 arg) {
     final argStorage = arg.storage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
     var v2 = _v3storage[2];
-    _v3storage[0] = argStorage[0] * v0 + argStorage[3] * v1 + argStorage[6] * v2;
-    _v3storage[1] = argStorage[1] * v0 + argStorage[4] * v1 + argStorage[7] * v2;
-    _v3storage[2] = argStorage[2] * v0 + argStorage[5] * v1 + argStorage[8] * v2;
-    return this;
+    _v3storage[0] =
+        argStorage[0] * v0 + argStorage[3] * v1 + argStorage[6] * v2;
+    _v3storage[1] =
+        argStorage[1] * v0 + argStorage[4] * v1 + argStorage[7] * v2;
+    _v3storage[2] =
+        argStorage[2] * v0 + argStorage[5] * v1 + argStorage[8] * v2;
   }
 
   /// Multiplies [this] by a 4x3 subset of [arg]. Expects [arg] to be an affine
   /// transformation matrix.
-  Vector3 applyMatrix4(Matrix4 arg) {
+  void applyMatrix4(Matrix4 arg) {
     final argStorage = arg.storage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
@@ -376,7 +366,6 @@ class Vector3 implements Vector {
         argStorage[6] * v1 +
         argStorage[10] * v2 +
         argStorage[14];
-    return this;
   }
 
   /// Relative error between [this] and [correct]
@@ -410,56 +399,50 @@ class Vector3 implements Vector {
   }
 
   /// Add [arg] to [this].
-  Vector3 add(Vector3 arg) {
+  void add(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0];
     _v3storage[1] = _v3storage[1] + argStorage[1];
     _v3storage[2] = _v3storage[2] + argStorage[2];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector3 addScaled(Vector3 arg, double factor) {
+  void addScaled(Vector3 arg, double factor) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0] * factor;
     _v3storage[1] = _v3storage[1] + argStorage[1] * factor;
     _v3storage[2] = _v3storage[2] + argStorage[2] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector3 sub(Vector3 arg) {
+  void sub(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] - argStorage[0];
     _v3storage[1] = _v3storage[1] - argStorage[1];
     _v3storage[2] = _v3storage[2] - argStorage[2];
-    return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
-  Vector3 multiply(Vector3 arg) {
+  void multiply(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] * argStorage[0];
     _v3storage[1] = _v3storage[1] * argStorage[1];
     _v3storage[2] = _v3storage[2] * argStorage[2];
-    return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
-  Vector3 divide(Vector3 arg) {
+  void divide(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] / argStorage[0];
     _v3storage[1] = _v3storage[1] / argStorage[1];
     _v3storage[2] = _v3storage[2] / argStorage[2];
-    return this;
   }
 
   /// Scale [this].
-  Vector3 scale(double arg) {
+  void scale(double arg) {
     _v3storage[2] = _v3storage[2] * arg;
     _v3storage[1] = _v3storage[1] * arg;
     _v3storage[0] = _v3storage[0] * arg;
-    return this;
   }
 
   /// Create a copy of [this] and scale it by [arg].
@@ -480,49 +463,44 @@ class Vector3 implements Vector {
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector3 clamp(Vector3 min, Vector3 max) {
+  void clamp(Vector3 min, Vector3 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
     _v3storage[0] = _v3storage[0].clamp(minStorage[0], maxStorage[0]);
     _v3storage[1] = _v3storage[1].clamp(minStorage[1], maxStorage[1]);
     _v3storage[2] = _v3storage[2].clamp(minStorage[2], maxStorage[2]);
-    return this;
   }
 
   /// Clamp entries in [this] in the range [min]-[max].
-  Vector3 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v3storage[0] = _v3storage[0].clamp(min, max);
     _v3storage[1] = _v3storage[1].clamp(min, max);
     _v3storage[2] = _v3storage[2].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector3 floor() {
+  void floor() {
     _v3storage[0] = _v3storage[0].floorToDouble();
     _v3storage[1] = _v3storage[1].floorToDouble();
     _v3storage[2] = _v3storage[2].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector3 ceil() {
+  void ceil() {
     _v3storage[0] = _v3storage[0].ceilToDouble();
     _v3storage[1] = _v3storage[1].ceilToDouble();
     _v3storage[2] = _v3storage[2].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector3 round() {
+  void round() {
     _v3storage[0] = _v3storage[0].roundToDouble();
     _v3storage[1] = _v3storage[1].roundToDouble();
     _v3storage[2] = _v3storage[2].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector3 roundToZero() {
+  void roundToZero() {
     _v3storage[0] = _v3storage[0] < 0.0
         ? _v3storage[0].ceilToDouble()
         : _v3storage[0].floorToDouble();
@@ -532,7 +510,6 @@ class Vector3 implements Vector {
     _v3storage[2] = _v3storage[2] < 0.0
         ? _v3storage[2].ceilToDouble()
         : _v3storage[2].floorToDouble();
-    return this;
   }
 
   /// Clone of [this].

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -65,49 +65,44 @@ class Vector4 implements Vector {
       : _v4storage = new Float32List.view(buffer, offset, 4);
 
   /// Set the values of the vector.
-  Vector4 setValues(double x_, double y_, double z_, double w_) {
+  void setValues(double x_, double y_, double z_, double w_) {
     _v4storage[3] = w_;
     _v4storage[2] = z_;
     _v4storage[1] = y_;
     _v4storage[0] = x_;
-    return this;
   }
 
   /// Zero the vector.
-  Vector4 setZero() {
+  void setZero() {
     _v4storage[0] = 0.0;
     _v4storage[1] = 0.0;
     _v4storage[2] = 0.0;
     _v4storage[3] = 0.0;
-    return this;
   }
 
   /// Set to the identity vector.
-  Vector4 setIdentity() {
+  void setIdentity() {
     _v4storage[0] = 0.0;
     _v4storage[1] = 0.0;
     _v4storage[2] = 0.0;
     _v4storage[3] = 1.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector4 setFrom(Vector4 other) {
+  void setFrom(Vector4 other) {
     final otherStorage = other._v4storage;
     _v4storage[3] = otherStorage[3];
     _v4storage[2] = otherStorage[2];
     _v4storage[1] = otherStorage[1];
     _v4storage[0] = otherStorage[0];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector4 splat(double arg) {
+  void splat(double arg) {
     _v4storage[3] = arg;
     _v4storage[2] = arg;
     _v4storage[1] = arg;
     _v4storage[0] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -177,22 +172,7 @@ class Vector4 implements Vector {
   }
 
   /// Normalizes [this].
-  Vector4 normalize() {
-    double l = length;
-    // TODO(johnmccutchan): Use an epsilon.
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v4storage[0] *= l;
-    _v4storage[1] *= l;
-    _v4storage[2] *= l;
-    _v4storage[3] *= l;
-    return this;
-  }
-
-  /// Normalizes [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -205,13 +185,20 @@ class Vector4 implements Vector {
     return l;
   }
 
+  /// Normalizes [this]. Returns length of vector before normalization.
+  /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalizes copy of [this].
   Vector4 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector4 normalizeInto(Vector4 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -240,7 +227,7 @@ class Vector4 implements Vector {
   }
 
   /// Multiplies [this] by [arg].
-  Vector4 applyMatrix4(Matrix4 arg) {
+  void applyMatrix4(Matrix4 arg) {
     var v1 = _v4storage[0];
     var v2 = _v4storage[1];
     var v3 = _v4storage[2];
@@ -262,7 +249,6 @@ class Vector4 implements Vector {
         argStorage[7] * v2 +
         argStorage[11] * v3 +
         argStorage[15] * v4;
-    return this;
   }
 
   /// Relative error between [this] and [correct]
@@ -297,134 +283,121 @@ class Vector4 implements Vector {
     return is_nan;
   }
 
-  Vector4 add(Vector4 arg) {
+  void add(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] + argStorage[0];
     _v4storage[1] = _v4storage[1] + argStorage[1];
     _v4storage[2] = _v4storage[2] + argStorage[2];
     _v4storage[3] = _v4storage[3] + argStorage[3];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector4 addScaled(Vector4 arg, double factor) {
+  void addScaled(Vector4 arg, double factor) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] + argStorage[0] * factor;
     _v4storage[1] = _v4storage[1] + argStorage[1] * factor;
     _v4storage[2] = _v4storage[2] + argStorage[2] * factor;
     _v4storage[3] = _v4storage[3] + argStorage[3] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector4 sub(Vector4 arg) {
+  void sub(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] - argStorage[0];
     _v4storage[1] = _v4storage[1] - argStorage[1];
     _v4storage[2] = _v4storage[2] - argStorage[2];
     _v4storage[3] = _v4storage[3] - argStorage[3];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Vector4 multiply(Vector4 arg) {
+  void multiply(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] * argStorage[0];
     _v4storage[1] = _v4storage[1] * argStorage[1];
     _v4storage[2] = _v4storage[2] * argStorage[2];
     _v4storage[3] = _v4storage[3] * argStorage[3];
-    return this;
   }
 
   /// Divide [this] by [arg].
-  Vector4 div(Vector4 arg) {
+  void div(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] / argStorage[0];
     _v4storage[1] = _v4storage[1] / argStorage[1];
     _v4storage[2] = _v4storage[2] / argStorage[2];
     _v4storage[3] = _v4storage[3] / argStorage[3];
-    return this;
   }
 
   /// Scale [this] by [arg].
-  Vector4 scale(double arg) {
+  void scale(double arg) {
     _v4storage[0] = _v4storage[0] * arg;
     _v4storage[1] = _v4storage[1] * arg;
     _v4storage[2] = _v4storage[2] * arg;
     _v4storage[3] = _v4storage[3] * arg;
-    return this;
   }
 
   /// Create a copy of [this] scaled by [arg].
   Vector4 scaled(double arg) => clone()..scale(arg);
 
   /// Negate [this].
-  Vector4 negate() {
+  void negate() {
     _v4storage[0] = -_v4storage[0];
     _v4storage[1] = -_v4storage[1];
     _v4storage[2] = -_v4storage[2];
     _v4storage[3] = -_v4storage[3];
-    return this;
   }
 
   /// Set [this] to the absolute.
-  Vector4 absolute() {
+  void absolute() {
     _v4storage[3] = _v4storage[3].abs();
     _v4storage[2] = _v4storage[2].abs();
     _v4storage[1] = _v4storage[1].abs();
     _v4storage[0] = _v4storage[0].abs();
-    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector4 clamp(Vector4 min, Vector4 max) {
+  void clamp(Vector4 min, Vector4 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
     _v4storage[0] = _v4storage[0].clamp(minStorage[0], maxStorage[0]);
     _v4storage[1] = _v4storage[1].clamp(minStorage[1], maxStorage[1]);
     _v4storage[2] = _v4storage[2].clamp(minStorage[2], maxStorage[2]);
     _v4storage[3] = _v4storage[3].clamp(minStorage[3], maxStorage[3]);
-    return this;
   }
 
   /// Clamp entries in [this] in the range [min]-[max].
-  Vector4 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v4storage[0] = _v4storage[0].clamp(min, max);
     _v4storage[1] = _v4storage[1].clamp(min, max);
     _v4storage[2] = _v4storage[2].clamp(min, max);
     _v4storage[3] = _v4storage[3].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector4 floor() {
+  void floor() {
     _v4storage[0] = _v4storage[0].floorToDouble();
     _v4storage[1] = _v4storage[1].floorToDouble();
     _v4storage[2] = _v4storage[2].floorToDouble();
     _v4storage[3] = _v4storage[3].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector4 ceil() {
+  void ceil() {
     _v4storage[0] = _v4storage[0].ceilToDouble();
     _v4storage[1] = _v4storage[1].ceilToDouble();
     _v4storage[2] = _v4storage[2].ceilToDouble();
     _v4storage[3] = _v4storage[3].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector4 round() {
+  void round() {
     _v4storage[0] = _v4storage[0].roundToDouble();
     _v4storage[1] = _v4storage[1].roundToDouble();
     _v4storage[2] = _v4storage[2].roundToDouble();
     _v4storage[3] = _v4storage[3].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector4 roundToZero() {
+  void roundToZero() {
     _v4storage[0] = _v4storage[0] < 0.0
         ? _v4storage[0].ceilToDouble()
         : _v4storage[0].floorToDouble();
@@ -437,7 +410,6 @@ class Vector4 implements Vector {
     _v4storage[3] = _v4storage[3] < 0.0
         ? _v4storage[3].ceilToDouble()
         : _v4storage[3].floorToDouble();
-    return this;
   }
 
   /// Create a copy of [this].

--- a/lib/src/vector_math_64/aabb2.dart
+++ b/lib/src/vector_math_64/aabb2.dart
@@ -76,7 +76,7 @@ class Aabb2 {
   }
 
   /// Transform [this] by the transform [t].
-  Aabb2 transform(Matrix3 t) {
+  void transform(Matrix3 t) {
     final center = new Vector2.zero();
     final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -89,11 +89,10 @@ class Aabb2 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Rotate [this] by the rotation matrix [t].
-  Aabb2 rotate(Matrix3 t) {
+  void rotate(Matrix3 t) {
     final center = new Vector2.zero();
     final halfExtents = new Vector2.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -104,7 +103,6 @@ class Aabb2 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Create a copy of [this] that is transformed by the transform [t] and store

--- a/lib/src/vector_math_64/aabb3.dart
+++ b/lib/src/vector_math_64/aabb3.dart
@@ -195,7 +195,7 @@ class Aabb3 {
   }
 
   /// Transform [this] by the transform [t].
-  Aabb3 transform(Matrix4 t) {
+  void transform(Matrix4 t) {
     final center = new Vector3.zero();
     final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -208,11 +208,10 @@ class Aabb3 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Rotate [this] by the rotation matrix [t].
-  Aabb3 rotate(Matrix4 t) {
+  void rotate(Matrix4 t) {
     final center = new Vector3.zero();
     final halfExtents = new Vector3.zero();
     copyCenterAndHalfExtents(center, halfExtents);
@@ -223,7 +222,6 @@ class Aabb3 {
     _max
       ..setFrom(center)
       ..add(halfExtents);
-    return this;
   }
 
   /// Create a copy of [this] that is transformed by the transform [t] and store

--- a/lib/src/vector_math_64/constants.dart
+++ b/lib/src/vector_math_64/constants.dart
@@ -8,4 +8,3 @@ part of vector_math_64;
 const double degrees2Radians = Math.PI / 180.0;
 /// Constant factor to convert and angle from radians to degrees.
 const double radians2Degrees = 180.0 / Math.PI;
-

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -75,59 +75,53 @@ class Matrix2 {
       new Matrix2.zero()..setRotation(radians);
 
   /// Sets the matrix with specified values.
-  Matrix2 setValues(double arg0, double arg1, double arg2, double arg3) {
+  void setValues(double arg0, double arg1, double arg2, double arg3) {
     _m2storage[3] = arg3;
     _m2storage[2] = arg2;
     _m2storage[1] = arg1;
     _m2storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix2 setColumns(Vector2 arg0, Vector2 arg1) {
+  void setColumns(Vector2 arg0, Vector2 arg1) {
     final arg0Storage = arg0._v2storage;
     final arg1Storage = arg1._v2storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
     _m2storage[3] = arg1Storage[1];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix2 setFrom(Matrix2 arg) {
+  void setFrom(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m2storage[3] = argStorage[3];
     _m2storage[2] = argStorage[2];
     _m2storage[1] = argStorage[1];
     _m2storage[0] = argStorage[0];
-    return this;
   }
 
   /// Set [this] to the outer product of [u] and [v].
-  Matrix2 setOuter(Vector2 u, Vector2 v) {
+  void setOuter(Vector2 u, Vector2 v) {
     final uStorage = u._v2storage;
     final vStorage = v._v2storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
     _m2storage[3] = uStorage[1] * vStorage[1];
-    return this;
   }
 
   /// Sets the diagonal to [arg].
-  Matrix2 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m2storage[0] = arg;
     _m2storage[3] = arg;
-    return this;
   }
 
   /// Sets the diagonal of the matrix to be [arg].
-  Matrix2 setDiagonal(Vector2 arg) {
+  void setDiagonal(Vector2 arg) {
     final argStorage = arg._v2storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
-    return this;
   }
 
   /// Returns a printable string
@@ -225,31 +219,28 @@ class Matrix2 {
   Matrix2 operator -() => clone()..negate();
 
   /// Zeros [this].
-  Matrix2 setZero() {
+  void setZero() {
     _m2storage[0] = 0.0;
     _m2storage[1] = 0.0;
     _m2storage[2] = 0.0;
     _m2storage[3] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix2 setIdentity() {
+  void setIdentity() {
     _m2storage[0] = 1.0;
     _m2storage[1] = 0.0;
     _m2storage[2] = 0.0;
     _m2storage[3] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix2 transposed() => clone()..transpose();
 
-  Matrix2 transpose() {
+  void transpose() {
     double temp = _m2storage[2];
     _m2storage[2] = _m2storage[1];
     _m2storage[1] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -363,58 +354,53 @@ class Matrix2 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix2 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     double temp = _m2storage[0];
     _m2storage[0] = _m2storage[3] * scale;
     _m2storage[2] = -_m2storage[2] * scale;
     _m2storage[1] = -_m2storage[1] * scale;
     _m2storage[3] = temp * scale;
-    return this;
   }
 
   /// Scale [this] by [scale].
-  Matrix2 scale(double scale) {
+  void scale(double scale) {
     _m2storage[0] = _m2storage[0] * scale;
     _m2storage[1] = _m2storage[1] * scale;
     _m2storage[2] = _m2storage[2] * scale;
     _m2storage[3] = _m2storage[3] * scale;
-    return this;
   }
 
   /// Create a copy of [this] scaled by [scale].
   Matrix2 scaled(double scale) => clone()..scale(scale);
 
   /// Add [o] to [this].
-  Matrix2 add(Matrix2 o) {
+  void add(Matrix2 o) {
     final oStorage = o._m2storage;
     _m2storage[0] = _m2storage[0] + oStorage[0];
     _m2storage[1] = _m2storage[1] + oStorage[1];
     _m2storage[2] = _m2storage[2] + oStorage[2];
     _m2storage[3] = _m2storage[3] + oStorage[3];
-    return this;
   }
 
   /// Subtract [o] from [this].
-  Matrix2 sub(Matrix2 o) {
+  void sub(Matrix2 o) {
     final oStorage = o._m2storage;
     _m2storage[0] = _m2storage[0] - oStorage[0];
     _m2storage[1] = _m2storage[1] - oStorage[1];
     _m2storage[2] = _m2storage[2] - oStorage[2];
     _m2storage[3] = _m2storage[3] - oStorage[3];
-    return this;
   }
 
   /// Negate [this].
-  Matrix2 negate() {
+  void negate() {
     _m2storage[0] = -_m2storage[0];
     _m2storage[1] = -_m2storage[1];
     _m2storage[2] = -_m2storage[2];
     _m2storage[3] = -_m2storage[3];
-    return this;
   }
 
   /// Multiply [this] with [arg] and store it in [this].
-  Matrix2 multiply(Matrix2 arg) {
+  void multiply(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[2];
     final m10 = _m2storage[1];
@@ -428,14 +414,13 @@ class Matrix2 {
     _m2storage[2] = (m00 * n01) + (m01 * n11);
     _m2storage[1] = (m10 * n00) + (m11 * n10);
     _m2storage[3] = (m10 * n01) + (m11 * n11);
-    return this;
   }
 
   /// Multiply [this] with [arg] and return the product.
   Matrix2 multiplied(Matrix2 arg) => clone()..multiply(arg);
 
   /// Multiply a transposed [this] with [arg].
-  Matrix2 transposeMultiply(Matrix2 arg) {
+  void transposeMultiply(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[1];
     final m10 = _m2storage[2];
@@ -445,11 +430,10 @@ class Matrix2 {
     _m2storage[2] = (m00 * argStorage[2]) + (m01 * argStorage[3]);
     _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[1]);
     _m2storage[3] = (m10 * argStorage[2]) + (m11 * argStorage[3]);
-    return this;
   }
 
   /// Multiply [this] with a transposed [arg].
-  Matrix2 multiplyTranspose(Matrix2 arg) {
+  void multiplyTranspose(Matrix2 arg) {
     final m00 = _m2storage[0];
     final m01 = _m2storage[2];
     final m10 = _m2storage[1];
@@ -459,7 +443,6 @@ class Matrix2 {
     _m2storage[2] = (m00 * argStorage[1]) + (m01 * argStorage[3]);
     _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[2]);
     _m2storage[3] = (m10 * argStorage[1]) + (m11 * argStorage[3]);
-    return this;
   }
 
   /// Transform [arg] of type [Vector2] using the transformation defined by

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -132,7 +132,7 @@ class Matrix3 {
       new Matrix3.zero()..setRotationZ(radians);
 
   /// Sets the matrix with specified values.
-  Matrix3 setValues(double arg0, double arg1, double arg2, double arg3,
+  void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
     _m3storage[8] = arg8;
     _m3storage[7] = arg7;
@@ -143,11 +143,10 @@ class Matrix3 {
     _m3storage[2] = arg2;
     _m3storage[1] = arg1;
     _m3storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix3 setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
+  void setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
     final arg0Storage = arg0._v3storage;
     final arg1Storage = arg1._v3storage;
     final arg2Storage = arg2._v3storage;
@@ -160,11 +159,10 @@ class Matrix3 {
     _m3storage[6] = arg2Storage[0];
     _m3storage[7] = arg2Storage[1];
     _m3storage[8] = arg2Storage[2];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix3 setFrom(Matrix3 arg) {
+  void setFrom(Matrix3 arg) {
     final argStorage = arg._m3storage;
     _m3storage[8] = argStorage[8];
     _m3storage[7] = argStorage[7];
@@ -175,11 +173,10 @@ class Matrix3 {
     _m3storage[2] = argStorage[2];
     _m3storage[1] = argStorage[1];
     _m3storage[0] = argStorage[0];
-    return this;
   }
 
   /// Set [this] to the outer product of [u] and [v].
-  Matrix3 setOuter(Vector3 u, Vector3 v) {
+  void setOuter(Vector3 u, Vector3 v) {
     final uStorage = u._v3storage;
     final vStorage = v._v3storage;
     _m3storage[0] = uStorage[0] * vStorage[0];
@@ -191,33 +188,29 @@ class Matrix3 {
     _m3storage[6] = uStorage[2] * vStorage[0];
     _m3storage[7] = uStorage[2] * vStorage[1];
     _m3storage[8] = uStorage[2] * vStorage[2];
-    return this;
   }
 
   /// Set the diagonal of the matrix.
-  Matrix3 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m3storage[0] = arg;
     _m3storage[4] = arg;
     _m3storage[8] = arg;
-    return this;
   }
 
   /// Set the diagonal of the matrix.
-  Matrix3 setDiagonal(Vector3 arg) {
+  void setDiagonal(Vector3 arg) {
     _m3storage[0] = arg.storage[0];
     _m3storage[4] = arg.storage[1];
     _m3storage[8] = arg.storage[2];
-    return this;
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
-  Matrix3 setUpper2x2(Matrix2 arg) {
+  void setUpper2x2(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m3storage[0] = argStorage[0];
     _m3storage[1] = argStorage[1];
     _m3storage[3] = argStorage[2];
     _m3storage[4] = argStorage[3];
-    return this;
   }
 
   /// Returns a printable string
@@ -332,7 +325,7 @@ class Matrix3 {
   Matrix3 operator -() => clone()..negate();
 
   /// Zeros [this].
-  Matrix3 setZero() {
+  void setZero() {
     _m3storage[0] = 0.0;
     _m3storage[1] = 0.0;
     _m3storage[2] = 0.0;
@@ -342,11 +335,10 @@ class Matrix3 {
     _m3storage[6] = 0.0;
     _m3storage[7] = 0.0;
     _m3storage[8] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix3 setIdentity() {
+  void setIdentity() {
     _m3storage[0] = 1.0;
     _m3storage[1] = 0.0;
     _m3storage[2] = 0.0;
@@ -356,14 +348,13 @@ class Matrix3 {
     _m3storage[6] = 0.0;
     _m3storage[7] = 0.0;
     _m3storage[8] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix3 transposed() => clone()..transpose();
 
   /// Transpose [this].
-  Matrix3 transpose() {
+  void transpose() {
     double temp;
     temp = _m3storage[3];
     _m3storage[3] = _m3storage[1];
@@ -374,7 +365,6 @@ class Matrix3 {
     temp = _m3storage[7];
     _m3storage[7] = _m3storage[5];
     _m3storage[5] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -516,10 +506,9 @@ class Matrix3 {
   }
 
   /// Set this matrix to be the normal matrix of [arg].
-  Matrix3 copyNormalMatrix(Matrix4 arg) {
+  void copyNormalMatrix(Matrix4 arg) {
     copyInverse(arg.getRotation());
     transpose();
-    return this;
   }
 
   /// Turns the matrix into a rotation of [radians] around X
@@ -568,7 +557,7 @@ class Matrix3 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix3 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[3];
     double m02 = _m3storage[6];
@@ -587,7 +576,6 @@ class Matrix3 {
     _m3storage[6] = (m01 * m12 - m02 * m11) * scale;
     _m3storage[7] = (m02 * m10 - m00 * m12) * scale;
     _m3storage[8] = (m00 * m11 - m01 * m10) * scale;
-    return this;
   }
 
   /// Rotates [arg] by the absolute rotation of [this]
@@ -660,7 +648,7 @@ class Matrix3 {
   Matrix3 scaled(double scale) => clone()..scale(scale);
 
   /// Add [o] to [this].
-  Matrix3 add(Matrix3 o) {
+  void add(Matrix3 o) {
     final oStorage = o._m3storage;
     _m3storage[0] = _m3storage[0] + oStorage[0];
     _m3storage[1] = _m3storage[1] + oStorage[1];
@@ -671,11 +659,10 @@ class Matrix3 {
     _m3storage[6] = _m3storage[6] + oStorage[6];
     _m3storage[7] = _m3storage[7] + oStorage[7];
     _m3storage[8] = _m3storage[8] + oStorage[8];
-    return this;
   }
 
   /// Subtract [o] from [this].
-  Matrix3 sub(Matrix3 o) {
+  void sub(Matrix3 o) {
     final oStorage = o._m3storage;
     _m3storage[0] = _m3storage[0] - oStorage[0];
     _m3storage[1] = _m3storage[1] - oStorage[1];
@@ -686,11 +673,10 @@ class Matrix3 {
     _m3storage[6] = _m3storage[6] - oStorage[6];
     _m3storage[7] = _m3storage[7] - oStorage[7];
     _m3storage[8] = _m3storage[8] - oStorage[8];
-    return this;
   }
 
   /// Negate [this].
-  Matrix3 negate() {
+  void negate() {
     _m3storage[0] = -_m3storage[0];
     _m3storage[1] = -_m3storage[1];
     _m3storage[2] = -_m3storage[2];
@@ -700,11 +686,10 @@ class Matrix3 {
     _m3storage[6] = -_m3storage[6];
     _m3storage[7] = -_m3storage[7];
     _m3storage[8] = -_m3storage[8];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Matrix3 multiply(Matrix3 arg) {
+  void multiply(Matrix3 arg) {
     final double m00 = _m3storage[0];
     final double m01 = _m3storage[3];
     final double m02 = _m3storage[6];
@@ -733,13 +718,12 @@ class Matrix3 {
     _m3storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
     _m3storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
     _m3storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
-    return this;
   }
 
   /// Create a copy of [this] and multiply it by [arg].
   Matrix3 multiplied(Matrix3 arg) => clone()..multiply(arg);
 
-  Matrix3 transposeMultiply(Matrix3 arg) {
+  void transposeMultiply(Matrix3 arg) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[1];
     double m02 = _m3storage[2];
@@ -768,10 +752,9 @@ class Matrix3 {
         (m20 * argStorage[3]) + (m21 * arg.storage[4]) + (m22 * arg.storage[5]);
     _m3storage[8] =
         (m20 * argStorage[6]) + (m21 * arg.storage[7]) + (m22 * arg.storage[8]);
-    return this;
   }
 
-  Matrix3 multiplyTranspose(Matrix3 arg) {
+  void multiplyTranspose(Matrix3 arg) {
     double m00 = _m3storage[0];
     double m01 = _m3storage[3];
     double m02 = _m3storage[6];
@@ -800,7 +783,6 @@ class Matrix3 {
         (m20 * argStorage[1]) + (m21 * argStorage[4]) + (m22 * argStorage[7]);
     _m3storage[8] =
         (m20 * argStorage[2]) + (m21 * argStorage[5]) + (m22 * argStorage[8]);
-    return this;
   }
 
   /// Transform [arg] of type [Vector3] using the transformation defined by

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -254,16 +254,15 @@ class Matrix4 {
     ..setFromTranslationRotationScale(translation, rotation, scale);
 
   /// Sets the diagonal to [arg].
-  Matrix4 splatDiagonal(double arg) {
+  void splatDiagonal(double arg) {
     _m4storage[0] = arg;
     _m4storage[5] = arg;
     _m4storage[10] = arg;
     _m4storage[15] = arg;
-    return this;
   }
 
   /// Sets the matrix with specified values.
-  Matrix4 setValues(double arg0, double arg1, double arg2, double arg3,
+  void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8,
       double arg9, double arg10, double arg11, double arg12, double arg13,
       double arg14, double arg15) {
@@ -283,11 +282,10 @@ class Matrix4 {
     _m4storage[2] = arg2;
     _m4storage[1] = arg1;
     _m4storage[0] = arg0;
-    return this;
   }
 
   /// Sets the entire matrix to the column values.
-  Matrix4 setColumns(Vector4 arg0, Vector4 arg1, Vector4 arg2, Vector4 arg3) {
+  void setColumns(Vector4 arg0, Vector4 arg1, Vector4 arg2, Vector4 arg3) {
     final arg0Storage = arg0._v4storage;
     final arg1Storage = arg1._v4storage;
     final arg2Storage = arg2._v4storage;
@@ -308,11 +306,10 @@ class Matrix4 {
     _m4storage[13] = arg3Storage[1];
     _m4storage[14] = arg3Storage[2];
     _m4storage[15] = arg3Storage[3];
-    return this;
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  Matrix4 setFrom(Matrix4 arg) {
+  void setFrom(Matrix4 arg) {
     final argStorage = arg._m4storage;
     _m4storage[15] = argStorage[15];
     _m4storage[14] = argStorage[14];
@@ -330,11 +327,10 @@ class Matrix4 {
     _m4storage[2] = argStorage[2];
     _m4storage[1] = argStorage[1];
     _m4storage[0] = argStorage[0];
-    return this;
   }
 
   /// Sets the matrix from translation [arg0] and rotation [arg1].
-  Matrix4 setFromTranslationRotation(Vector3 arg0, Quaternion arg1) {
+  void setFromTranslationRotation(Vector3 arg0, Quaternion arg1) {
     final arg1Storage = arg1._qStorage;
     double x = arg1Storage[0];
     double y = arg1Storage[1];
@@ -370,35 +366,31 @@ class Matrix4 {
     _m4storage[13] = arg0Storage[1];
     _m4storage[14] = arg0Storage[2];
     _m4storage[15] = 1.0;
-    return this;
   }
 
   /// Sets the matrix from [translation], [rotation] and [scale].
-  Matrix4 setFromTranslationRotationScale(
+  void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
     this.scale(scale);
-    return this;
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
-  Matrix4 setUpper2x2(Matrix2 arg) {
+  void setUpper2x2(Matrix2 arg) {
     final argStorage = arg._m2storage;
     _m4storage[0] = argStorage[0];
     _m4storage[1] = argStorage[1];
     _m4storage[4] = argStorage[2];
     _m4storage[5] = argStorage[3];
-    return this;
   }
 
   /// Sets the diagonal of the matrix to be [arg].
-  Matrix4 setDiagonal(Vector4 arg) {
+  void setDiagonal(Vector4 arg) {
     final argStorage = arg._v4storage;
     _m4storage[0] = argStorage[0];
     _m4storage[5] = argStorage[1];
     _m4storage[10] = argStorage[2];
     _m4storage[15] = argStorage[3];
-    return this;
   }
 
   void setOuter(Vector4 u, Vector4 v) {
@@ -553,7 +545,7 @@ class Matrix4 {
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
   /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
-  Matrix4 translate(x, [double y = 0.0, double z = 0.0]) {
+  void translate(x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
     double tz;
@@ -587,11 +579,10 @@ class Matrix4 {
     _m4storage[13] = t2;
     _m4storage[14] = t3;
     _m4storage[15] = t4;
-    return this;
   }
 
   /// Rotate this [angle] radians around [axis]
-  Matrix4 rotate(Vector3 axis, double angle) {
+  void rotate(Vector3 axis, double angle) {
     var len = axis.length;
     final axisStorage = axis._v3storage;
     var x = axisStorage[0] / len;
@@ -633,11 +624,10 @@ class Matrix4 {
     _m4storage[9] = t10;
     _m4storage[10] = t11;
     _m4storage[11] = t12;
-    return this;
   }
 
   /// Rotate this [angle] radians around X
-  Matrix4 rotateX(double angle) {
+  void rotateX(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[4] * cosAngle + _m4storage[8] * sinAngle;
@@ -656,11 +646,10 @@ class Matrix4 {
     _m4storage[9] = t6;
     _m4storage[10] = t7;
     _m4storage[11] = t8;
-    return this;
   }
 
   /// Rotate this matrix [angle] radians around Y
-  Matrix4 rotateY(double angle) {
+  void rotateY(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[0] * cosAngle + _m4storage[8] * -sinAngle;
@@ -679,11 +668,10 @@ class Matrix4 {
     _m4storage[9] = t6;
     _m4storage[10] = t7;
     _m4storage[11] = t8;
-    return this;
   }
 
   /// Rotate this matrix [angle] radians around Z
-  Matrix4 rotateZ(double angle) {
+  void rotateZ(double angle) {
     double cosAngle = Math.cos(angle);
     double sinAngle = Math.sin(angle);
     var t1 = _m4storage[0] * cosAngle + _m4storage[4] * sinAngle;
@@ -702,11 +690,10 @@ class Matrix4 {
     _m4storage[5] = t6;
     _m4storage[6] = t7;
     _m4storage[7] = t8;
-    return this;
   }
 
   /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
-  Matrix4 scale(x, [double y, double z]) {
+  void scale(x, [double y, double z]) {
     double sx;
     double sy;
     double sz;
@@ -736,7 +723,6 @@ class Matrix4 {
     _m4storage[13] *= sw;
     _m4storage[14] *= sw;
     _m4storage[15] *= sw;
-    return this;
   }
 
   /// Create a copy of [this] scaled by a [Vector3], [Vector4] or [x],[y], and
@@ -745,7 +731,7 @@ class Matrix4 {
       clone()..scale(x, y, z);
 
   /// Zeros [this].
-  Matrix4 setZero() {
+  void setZero() {
     _m4storage[0] = 0.0;
     _m4storage[1] = 0.0;
     _m4storage[2] = 0.0;
@@ -762,11 +748,10 @@ class Matrix4 {
     _m4storage[13] = 0.0;
     _m4storage[14] = 0.0;
     _m4storage[15] = 0.0;
-    return this;
   }
 
   /// Makes [this] into the identity matrix.
-  Matrix4 setIdentity() {
+  void setIdentity() {
     _m4storage[0] = 1.0;
     _m4storage[1] = 0.0;
     _m4storage[2] = 0.0;
@@ -783,13 +768,12 @@ class Matrix4 {
     _m4storage[13] = 0.0;
     _m4storage[14] = 0.0;
     _m4storage[15] = 1.0;
-    return this;
   }
 
   /// Returns the tranpose of this.
   Matrix4 transposed() => clone()..transpose();
 
-  Matrix4 transpose() {
+  void transpose() {
     double temp;
     temp = _m4storage[4];
     _m4storage[4] = _m4storage[1];
@@ -809,7 +793,6 @@ class Matrix4 {
     temp = _m4storage[14];
     _m4storage[14] = _m4storage[11];
     _m4storage[11] = temp;
-    return this;
   }
 
   /// Returns the component wise absolute value of this.
@@ -837,12 +820,18 @@ class Matrix4 {
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    double det2_01_01 = _m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4];
-    double det2_01_02 = _m4storage[0] * _m4storage[6] - _m4storage[2] * _m4storage[4];
-    double det2_01_03 = _m4storage[0] * _m4storage[7] - _m4storage[3] * _m4storage[4];
-    double det2_01_12 = _m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5];
-    double det2_01_13 = _m4storage[1] * _m4storage[7] - _m4storage[3] * _m4storage[5];
-    double det2_01_23 = _m4storage[2] * _m4storage[7] - _m4storage[3] * _m4storage[6];
+    double det2_01_01 =
+        _m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4];
+    double det2_01_02 =
+        _m4storage[0] * _m4storage[6] - _m4storage[2] * _m4storage[4];
+    double det2_01_03 =
+        _m4storage[0] * _m4storage[7] - _m4storage[3] * _m4storage[4];
+    double det2_01_12 =
+        _m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5];
+    double det2_01_13 =
+        _m4storage[1] * _m4storage[7] - _m4storage[3] * _m4storage[5];
+    double det2_01_23 =
+        _m4storage[2] * _m4storage[7] - _m4storage[3] * _m4storage[6];
     double det3_201_012 = _m4storage[8] * det2_01_12 -
         _m4storage[9] * det2_01_02 +
         _m4storage[10] * det2_01_01;
@@ -1025,7 +1014,7 @@ class Matrix4 {
   }
 
   /// Transposes just the upper 3x3 rotation matrix.
-  Matrix4 transposeRotation() {
+  void transposeRotation() {
     double temp;
     temp = _m4storage[1];
     _m4storage[1] = _m4storage[4];
@@ -1045,7 +1034,6 @@ class Matrix4 {
     temp = _m4storage[9];
     _m4storage[9] = _m4storage[6];
     _m4storage[6] = temp;
-    return this;
   }
 
   /// Invert [this].
@@ -1123,15 +1111,24 @@ class Matrix4 {
     double kx;
     double ky;
     double kz;
-    ix = invDet * (_m4storage[5] * _m4storage[10] - _m4storage[6] * _m4storage[9]);
-    iy = invDet * (_m4storage[2] * _m4storage[9] - _m4storage[1] * _m4storage[10]);
-    iz = invDet * (_m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5]);
-    jx = invDet * (_m4storage[6] * _m4storage[8] - _m4storage[4] * _m4storage[10]);
-    jy = invDet * (_m4storage[0] * _m4storage[10] - _m4storage[2] * _m4storage[8]);
-    jz = invDet * (_m4storage[2] * _m4storage[4] - _m4storage[0] * _m4storage[6]);
-    kx = invDet * (_m4storage[4] * _m4storage[9] - _m4storage[5] * _m4storage[8]);
-    ky = invDet * (_m4storage[1] * _m4storage[8] - _m4storage[0] * _m4storage[9]);
-    kz = invDet * (_m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4]);
+    ix = invDet *
+        (_m4storage[5] * _m4storage[10] - _m4storage[6] * _m4storage[9]);
+    iy = invDet *
+        (_m4storage[2] * _m4storage[9] - _m4storage[1] * _m4storage[10]);
+    iz = invDet *
+        (_m4storage[1] * _m4storage[6] - _m4storage[2] * _m4storage[5]);
+    jx = invDet *
+        (_m4storage[6] * _m4storage[8] - _m4storage[4] * _m4storage[10]);
+    jy = invDet *
+        (_m4storage[0] * _m4storage[10] - _m4storage[2] * _m4storage[8]);
+    jz = invDet *
+        (_m4storage[2] * _m4storage[4] - _m4storage[0] * _m4storage[6]);
+    kx = invDet *
+        (_m4storage[4] * _m4storage[9] - _m4storage[5] * _m4storage[8]);
+    ky = invDet *
+        (_m4storage[1] * _m4storage[8] - _m4storage[0] * _m4storage[9]);
+    kz = invDet *
+        (_m4storage[0] * _m4storage[5] - _m4storage[1] * _m4storage[4]);
     _m4storage[0] = ix;
     _m4storage[1] = iy;
     _m4storage[2] = iz;
@@ -1199,7 +1196,7 @@ class Matrix4 {
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
-  Matrix4 scaleAdjoint(double scale) {
+  void scaleAdjoint(double scale) {
     // Adapted from code by Richard Carling.
     double a1 = _m4storage[0];
     double b1 = _m4storage[4];
@@ -1281,7 +1278,6 @@ class Matrix4 {
             b1 * (a2 * c3 - a3 * c2) +
             c1 * (a2 * b3 - a3 * b2)) *
         scale;
-    return this;
   }
 
   /// Rotates [arg] by the absolute rotation of [this]
@@ -1308,7 +1304,7 @@ class Matrix4 {
   }
 
   /// Adds [o] to [this].
-  Matrix4 add(Matrix4 o) {
+  void add(Matrix4 o) {
     final oStorage = o._m4storage;
     _m4storage[0] = _m4storage[0] + oStorage[0];
     _m4storage[1] = _m4storage[1] + oStorage[1];
@@ -1326,11 +1322,10 @@ class Matrix4 {
     _m4storage[13] = _m4storage[13] + oStorage[13];
     _m4storage[14] = _m4storage[14] + oStorage[14];
     _m4storage[15] = _m4storage[15] + oStorage[15];
-    return this;
   }
 
   /// Subtracts [o] from [this].
-  Matrix4 sub(Matrix4 o) {
+  void sub(Matrix4 o) {
     final oStorage = o._m4storage;
     _m4storage[0] = _m4storage[0] - oStorage[0];
     _m4storage[1] = _m4storage[1] - oStorage[1];
@@ -1348,11 +1343,10 @@ class Matrix4 {
     _m4storage[13] = _m4storage[13] - oStorage[13];
     _m4storage[14] = _m4storage[14] - oStorage[14];
     _m4storage[15] = _m4storage[15] - oStorage[15];
-    return this;
   }
 
   /// Negate [this].
-  Matrix4 negate() {
+  void negate() {
     _m4storage[0] = -_m4storage[0];
     _m4storage[1] = -_m4storage[1];
     _m4storage[2] = -_m4storage[2];
@@ -1369,11 +1363,10 @@ class Matrix4 {
     _m4storage[13] = -_m4storage[13];
     _m4storage[14] = -_m4storage[14];
     _m4storage[15] = -_m4storage[15];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Matrix4 multiply(Matrix4 arg) {
+  void multiply(Matrix4 arg) {
     final m00 = _m4storage[0];
     final m01 = _m4storage[4];
     final m02 = _m4storage[8];
@@ -1423,14 +1416,13 @@ class Matrix4 {
     _m4storage[7] = (m30 * n01) + (m31 * n11) + (m32 * n21) + (m33 * n31);
     _m4storage[11] = (m30 * n02) + (m31 * n12) + (m32 * n22) + (m33 * n32);
     _m4storage[15] = (m30 * n03) + (m31 * n13) + (m32 * n23) + (m33 * n33);
-    return this;
   }
 
   /// Multiply a copy of [this] with [arg].
   Matrix4 multiplied(Matrix4 arg) => clone()..multiply(arg);
 
   /// Multiply a transposed [this] with [arg].
-  Matrix4 transposeMultiply(Matrix4 arg) {
+  void transposeMultiply(Matrix4 arg) {
     double m00 = _m4storage[0];
     double m01 = _m4storage[1];
     double m02 = _m4storage[2];
@@ -1512,11 +1504,10 @@ class Matrix4 {
         (m31 * argStorage[13]) +
         (m32 * argStorage[14]) +
         (m33 * argStorage[15]);
-    return this;
   }
 
   /// Multiply [this] with a transposed [arg].
-  Matrix4 multiplyTranspose(Matrix4 arg) {
+  void multiplyTranspose(Matrix4 arg) {
     double m00 = _m4storage[0];
     double m01 = _m4storage[4];
     double m02 = _m4storage[8];
@@ -1598,20 +1589,21 @@ class Matrix4 {
         (m31 * argStorage[7]) +
         (m32 * argStorage[11]) +
         (m33 * argStorage[15]);
-    return this;
   }
+
   /// Decomposes [this] into [translation], [rotation] and [scale] components.
   void decompose(Vector3 translation, Quaternion rotation, Vector3 scale) {
     final v = new Vector3.zero();
-    var sx = v.setValues(_m4storage[0], _m4storage[1], _m4storage[2]).length;
-    var sy = v.setValues(_m4storage[4], _m4storage[5], _m4storage[6]).length;
-    var sz = v.setValues(_m4storage[8], _m4storage[9], _m4storage[10]).length;
+    var sx = (v..setValues(_m4storage[0], _m4storage[1], _m4storage[2])).length;
+    var sy = (v..setValues(_m4storage[4], _m4storage[5], _m4storage[6])).length;
+    var sz = (v
+      ..setValues(_m4storage[8], _m4storage[9], _m4storage[10])).length;
 
     if (determinant() < 0) sx = -sx;
 
-    translation.storage[0] = _m4storage[12];
-    translation.storage[1] = _m4storage[13];
-    translation.storage[2] = _m4storage[14];
+    translation._v3storage[0] = _m4storage[12];
+    translation._v3storage[1] = _m4storage[13];
+    translation._v3storage[2] = _m4storage[14];
 
     final invSX = 1.0 / sx;
     final invSY = 1.0 / sy;
@@ -1630,9 +1622,9 @@ class Matrix4 {
 
     rotation.setFromRotation(m.getRotation());
 
-    scale.storage[0] = sx;
-    scale.storage[1] = sy;
-    scale.storage[2] = sz;
+    scale._v3storage[0] = sx;
+    scale._v3storage[1] = sy;
+    scale._v3storage[2] = sz;
   }
 
   /// Rotate [arg] of type [Vector3] using the rotation defined by [this].

--- a/lib/src/vector_math_64/obb3.dart
+++ b/lib/src/vector_math_64/obb3.dart
@@ -84,9 +84,9 @@ class Obb3 {
     t.transform(_axis0..scale(_halfExtents.x));
     t.transform(_axis1..scale(_halfExtents.y));
     t.transform(_axis2..scale(_halfExtents.z));
-    _halfExtents.x = _axis0.normalizeLength();
-    _halfExtents.y = _axis1.normalizeLength();
-    _halfExtents.z = _axis2.normalizeLength();
+    _halfExtents.x = _axis0.normalize();
+    _halfExtents.y = _axis1.normalize();
+    _halfExtents.z = _axis2.normalize();
   }
 
   /// Transform [this] by the transform [t].
@@ -95,9 +95,9 @@ class Obb3 {
     t.rotate3(_axis0..scale(_halfExtents.x));
     t.rotate3(_axis1..scale(_halfExtents.y));
     t.rotate3(_axis2..scale(_halfExtents.z));
-    _halfExtents.x = _axis0.normalizeLength();
-    _halfExtents.y = _axis1.normalizeLength();
-    _halfExtents.z = _axis2.normalizeLength();
+    _halfExtents.x = _axis0.normalize();
+    _halfExtents.y = _axis1.normalize();
+    _halfExtents.z = _axis2.normalize();
   }
 
   /// Store the corner with [cornerIndex] in [corner].

--- a/lib/src/vector_math_64/opengl.dart
+++ b/lib/src/vector_math_64/opengl.dart
@@ -56,7 +56,7 @@ void setRotationMatrix(
 /// [tx],[ty],[tz] specifies the position of the object.
 void setModelMatrix(Matrix4 modelMatrix, Vector3 forwardDirection,
     Vector3 upDirection, double tx, double ty, double tz) {
-  Vector3 right = forwardDirection.cross(upDirection).normalize();
+  Vector3 right = forwardDirection.cross(upDirection)..normalize();
   Vector3 c1 = right;
   Vector3 c2 = upDirection;
   Vector3 c3 = -forwardDirection;
@@ -150,7 +150,7 @@ void setFrustumMatrix(Matrix4 perspectiveMatrix, double left, double right,
   double right_minus_left = right - left;
   double top_minus_bottom = top - bottom;
   double far_minus_near = far - near;
-  Matrix4 view = perspectiveMatrix.setZero();
+  Matrix4 view = perspectiveMatrix..setZero();
   view.setEntry(0, 0, two_near / right_minus_left);
   view.setEntry(1, 1, two_near / top_minus_bottom);
   view.setEntry(0, 2, (right + left) / right_minus_left);
@@ -191,7 +191,7 @@ void setOrthographicMatrix(Matrix4 orthographicMatrix, double left,
   double tpb = top + bottom;
   double fmn = far - near;
   double fpn = far + near;
-  Matrix4 r = orthographicMatrix.setZero();
+  Matrix4 r = orthographicMatrix..setZero();
   r.setEntry(0, 0, 2.0 / rml);
   r.setEntry(1, 1, 2.0 / tmb);
   r.setEntry(2, 2, -2.0 / fmn);

--- a/lib/src/vector_math_64/quaternion.dart
+++ b/lib/src/vector_math_64/quaternion.dart
@@ -210,35 +210,33 @@ class Quaternion {
   }
 
   /// Normalize [this].
-  Quaternion normalize() {
-    var l = length;
+  double normalize() {
+    double l = length;
     if (l == 0.0) {
-      return this;
+      return 0.0;
     }
-    l = 1.0 / l;
-    _qStorage[3] = _qStorage[3] * l;
-    _qStorage[2] = _qStorage[2] * l;
-    _qStorage[1] = _qStorage[1] * l;
-    _qStorage[0] = _qStorage[0] * l;
-    return this;
+    var d = 1.0 / l;
+    _qStorage[0] *= d;
+    _qStorage[1] *= d;
+    _qStorage[2] *= d;
+    _qStorage[3] *= d;
+    return l;
   }
 
   /// Conjugate [this].
-  Quaternion conjugate() {
+  void conjugate() {
     _qStorage[2] = -_qStorage[2];
     _qStorage[1] = -_qStorage[1];
     _qStorage[0] = -_qStorage[0];
-    return this;
   }
 
   /// Invert [this].
-  Quaternion inverse() {
+  void inverse() {
     final l = 1.0 / length2;
     _qStorage[3] = _qStorage[3] * l;
     _qStorage[2] = -_qStorage[2] * l;
     _qStorage[1] = -_qStorage[1] * l;
     _qStorage[0] = -_qStorage[0] * l;
-    return this;
   }
 
   /// Normalized copy of [this].

--- a/lib/src/vector_math_64/vector.dart
+++ b/lib/src/vector_math_64/vector.dart
@@ -16,9 +16,7 @@ void cross3(Vector3 x, Vector3 y, Vector3 out) {
 }
 
 /// 2D cross product. vec2 x vec2.
-double cross2(Vector2 x, Vector2 y) {
-  return x.cross(y);
-}
+double cross2(Vector2 x, Vector2 y) => x.cross(y);
 
 /// 2D cross product. double x vec2.
 void cross2A(double x, Vector2 y, Vector2 out) {

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -55,32 +55,28 @@ class Vector2 implements Vector {
       : _v2storage = new Float64List.view(buffer, offset, 2);
 
   /// Set the values of the vector.
-  Vector2 setValues(double x_, double y_) {
+  void setValues(double x_, double y_) {
     _v2storage[0] = x_;
     _v2storage[1] = y_;
-    return this;
   }
 
   /// Zero the vector.
-  Vector2 setZero() {
+  void setZero() {
     _v2storage[0] = 0.0;
     _v2storage[1] = 0.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector2 setFrom(Vector2 other) {
+  void setFrom(Vector2 other) {
     final otherStorage = other._v2storage;
     _v2storage[1] = otherStorage[1];
     _v2storage[0] = otherStorage[0];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector2 splat(double arg) {
+  void splat(double arg) {
     _v2storage[0] = arg;
     _v2storage[1] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -143,20 +139,7 @@ class Vector2 implements Vector {
   }
 
   /// Normalize [this].
-  Vector2 normalize() {
-    double l = length;
-    // TODO(johnmccutchan): Use an epsilon.
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v2storage[0] *= l;
-    _v2storage[1] *= l;
-    return this;
-  }
-
-  /// Normalize [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -167,13 +150,20 @@ class Vector2 implements Vector {
     return l;
   }
 
+  /// Normalize [this]. Returns length of vector before normalization.
+  /// /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalized copy of [this].
   Vector2 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector2 normalizeInto(Vector2 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -202,14 +192,12 @@ class Vector2 implements Vector {
    * If [arg] is a rotation matrix, this is a computational shortcut for applying,
    * the inverse of the transformation.
    */
-  Vector2 postmultiply(Matrix2 arg) {
+  void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
     double v0 = _v2storage[0];
     double v1 = _v2storage[1];
     _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
     _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
-
-    return this;
   }
 
   /// Cross product.
@@ -225,9 +213,8 @@ class Vector2 implements Vector {
   }
 
   /// Reflect [this].
-  Vector2 reflect(Vector2 normal) {
+  void reflect(Vector2 normal) {
     sub(normal.scaled(2.0 * normal.dot(this)));
-    return this;
   }
 
   /// Reflected copy of [this].
@@ -262,115 +249,101 @@ class Vector2 implements Vector {
   }
 
   /// Add [arg] to [this].
-  Vector2 add(Vector2 arg) {
+  void add(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] + argStorage[0];
     _v2storage[1] = _v2storage[1] + argStorage[1];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector2 addScaled(Vector2 arg, double factor) {
+  void addScaled(Vector2 arg, double factor) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
     _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector2 sub(Vector2 arg) {
+  void sub(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] - argStorage[0];
     _v2storage[1] = _v2storage[1] - argStorage[1];
-    return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
-  Vector2 multiply(Vector2 arg) {
+  void multiply(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] * argStorage[0];
     _v2storage[1] = _v2storage[1] * argStorage[1];
-    return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
-  Vector2 divide(Vector2 arg) {
+  void divide(Vector2 arg) {
     final argStorage = arg._v2storage;
     _v2storage[0] = _v2storage[0] / argStorage[0];
     _v2storage[1] = _v2storage[1] / argStorage[1];
-    return this;
   }
 
   /// Scale [this] by [arg].
-  Vector2 scale(double arg) {
+  void scale(double arg) {
     _v2storage[1] = _v2storage[1] * arg;
     _v2storage[0] = _v2storage[0] * arg;
-    return this;
   }
 
   /// Return a copy of [this] scaled by [arg].
   Vector2 scaled(double arg) => clone()..scale(arg);
 
   /// Negate.
-  Vector2 negate() {
+  void negate() {
     _v2storage[1] = -_v2storage[1];
     _v2storage[0] = -_v2storage[0];
-    return this;
   }
 
   /// Absolute value.
-  Vector2 absolute() {
+  void absolute() {
     _v2storage[1] = _v2storage[1].abs();
     _v2storage[0] = _v2storage[0].abs();
-    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector2 clamp(Vector2 min, Vector2 max) {
+  void clamp(Vector2 min, Vector2 max) {
     var minStorage = min.storage;
     var maxStorage = max.storage;
     _v2storage[0] = _v2storage[0].clamp(minStorage[0], maxStorage[0]);
     _v2storage[1] = _v2storage[1].clamp(minStorage[1], maxStorage[1]);
-    return this;
   }
 
   /// Clamp entries [this] in the range [min]-[max].
-  Vector2 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v2storage[0] = _v2storage[0].clamp(min, max);
     _v2storage[1] = _v2storage[1].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector2 floor() {
+  void floor() {
     _v2storage[0] = _v2storage[0].floorToDouble();
     _v2storage[1] = _v2storage[1].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector2 ceil() {
+  void ceil() {
     _v2storage[0] = _v2storage[0].ceilToDouble();
     _v2storage[1] = _v2storage[1].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector2 round() {
+  void round() {
     _v2storage[0] = _v2storage[0].roundToDouble();
     _v2storage[1] = _v2storage[1].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector2 roundToZero() {
+  void roundToZero() {
     _v2storage[0] = _v2storage[0] < 0.0
         ? _v2storage[0].ceilToDouble()
         : _v2storage[0].floorToDouble();
     _v2storage[1] = _v2storage[1] < 0.0
         ? _v2storage[1].ceilToDouble()
         : _v2storage[1].floorToDouble();
-    return this;
   }
 
   /// Clone of [this].

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -59,36 +59,32 @@ class Vector3 implements Vector {
       : _v3storage = new Float64List.view(buffer, offset, 3);
 
   /// Set the values of the vector.
-  Vector3 setValues(double x_, double y_, double z_) {
+  void setValues(double x_, double y_, double z_) {
     _v3storage[0] = x_;
     _v3storage[1] = y_;
     _v3storage[2] = z_;
-    return this;
   }
 
   /// Zero vector.
-  Vector3 setZero() {
+  void setZero() {
     _v3storage[2] = 0.0;
     _v3storage[1] = 0.0;
     _v3storage[0] = 0.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector3 setFrom(Vector3 other) {
+  void setFrom(Vector3 other) {
     final otherStorage = other._v3storage;
     _v3storage[0] = otherStorage[0];
     _v3storage[1] = otherStorage[1];
     _v3storage[2] = otherStorage[2];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector3 splat(double arg) {
+  void splat(double arg) {
     _v3storage[2] = arg;
     _v3storage[1] = arg;
     _v3storage[0] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -154,20 +150,7 @@ class Vector3 implements Vector {
   }
 
   /// Normalizes [this].
-  Vector3 normalize() {
-    double l = length;
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v3storage[0] *= l;
-    _v3storage[1] *= l;
-    _v3storage[2] *= l;
-    return this;
-  }
-
-  /// Normalize [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -179,13 +162,20 @@ class Vector3 implements Vector {
     return l;
   }
 
+  /// Normalize [this]. Returns length of vector before normalization.
+  /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalizes copy of [this].
   Vector3 normalized() => new Vector3.copy(this)..normalize();
 
   /// Normalize vector into [out].
   Vector3 normalizeInto(Vector3 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -241,16 +231,18 @@ class Vector3 implements Vector {
    * If [arg] is a rotation matrix, this is a computational shortcut for applying,
    * the inverse of the transformation.
    */
-  Vector3 postmultiply(Matrix3 arg) {
+  void postmultiply(Matrix3 arg) {
     final argStorage = arg.storage;
     final v0 = _v3storage[0];
     final v1 = _v3storage[1];
     final v2 = _v3storage[2];
 
-    _v3storage[0] = v0 * argStorage[0] + v1 * argStorage[1] + v2 * argStorage[2];
-    _v3storage[1] = v0 * argStorage[3] + v1 * argStorage[4] + v2 * argStorage[5];
-    _v3storage[2] = v0 * argStorage[6] + v1 * argStorage[7] + v2 * argStorage[8];
-    return this;
+    _v3storage[0] =
+        v0 * argStorage[0] + v1 * argStorage[1] + v2 * argStorage[2];
+    _v3storage[1] =
+        v0 * argStorage[3] + v1 * argStorage[4] + v2 * argStorage[5];
+    _v3storage[2] =
+        v0 * argStorage[6] + v1 * argStorage[7] + v2 * argStorage[8];
   }
 
   /// Cross product.
@@ -282,16 +274,15 @@ class Vector3 implements Vector {
   }
 
   /// Reflect [this].
-  Vector3 reflect(Vector3 normal) {
+  void reflect(Vector3 normal) {
     sub(normal.scaled(2.0 * normal.dot(this)));
-    return this;
   }
 
   /// Reflected copy of [this].
   Vector3 reflected(Vector3 normal) => clone()..reflect(normal);
 
   /// Projects [this] using the projection matrix [arg]
-  Vector3 applyProjection(Matrix4 arg) {
+  void applyProjection(Matrix4 arg) {
     final argStorage = arg.storage;
     final x = _v3storage[0];
     final y = _v3storage[1];
@@ -316,17 +307,15 @@ class Vector3 implements Vector {
             argStorage[10] * z +
             argStorage[14]) *
         d;
-    return this;
   }
 
   /// Applies a rotation specified by [axis] and [angle].
-  Vector3 applyAxisAngle(Vector3 axis, double angle) {
+  void applyAxisAngle(Vector3 axis, double angle) {
     applyQuaternion(new Quaternion.axisAngle(axis, angle));
-    return this;
   }
 
   /// Applies a quaternion transform.
-  Vector3 applyQuaternion(Quaternion arg) {
+  void applyQuaternion(Quaternion arg) {
     final argStorage = arg._qStorage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
@@ -342,24 +331,25 @@ class Vector3 implements Vector {
     _v3storage[0] = ix * qw + iw * -qx + iy * -qz - iz * -qy;
     _v3storage[1] = iy * qw + iw * -qy + iz * -qx - ix * -qz;
     _v3storage[2] = iz * qw + iw * -qz + ix * -qy - iy * -qx;
-    return this;
   }
 
   /// Multiplies [this] by [arg].
-  Vector3 applyMatrix3(Matrix3 arg) {
+  void applyMatrix3(Matrix3 arg) {
     final argStorage = arg.storage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
     var v2 = _v3storage[2];
-    _v3storage[0] = argStorage[0] * v0 + argStorage[3] * v1 + argStorage[6] * v2;
-    _v3storage[1] = argStorage[1] * v0 + argStorage[4] * v1 + argStorage[7] * v2;
-    _v3storage[2] = argStorage[2] * v0 + argStorage[5] * v1 + argStorage[8] * v2;
-    return this;
+    _v3storage[0] =
+        argStorage[0] * v0 + argStorage[3] * v1 + argStorage[6] * v2;
+    _v3storage[1] =
+        argStorage[1] * v0 + argStorage[4] * v1 + argStorage[7] * v2;
+    _v3storage[2] =
+        argStorage[2] * v0 + argStorage[5] * v1 + argStorage[8] * v2;
   }
 
   /// Multiplies [this] by a 4x3 subset of [arg]. Expects [arg] to be an affine
   /// transformation matrix.
-  Vector3 applyMatrix4(Matrix4 arg) {
+  void applyMatrix4(Matrix4 arg) {
     final argStorage = arg.storage;
     var v0 = _v3storage[0];
     var v1 = _v3storage[1];
@@ -376,7 +366,6 @@ class Vector3 implements Vector {
         argStorage[6] * v1 +
         argStorage[10] * v2 +
         argStorage[14];
-    return this;
   }
 
   /// Relative error between [this] and [correct]
@@ -410,56 +399,50 @@ class Vector3 implements Vector {
   }
 
   /// Add [arg] to [this].
-  Vector3 add(Vector3 arg) {
+  void add(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0];
     _v3storage[1] = _v3storage[1] + argStorage[1];
     _v3storage[2] = _v3storage[2] + argStorage[2];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector3 addScaled(Vector3 arg, double factor) {
+  void addScaled(Vector3 arg, double factor) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0] * factor;
     _v3storage[1] = _v3storage[1] + argStorage[1] * factor;
     _v3storage[2] = _v3storage[2] + argStorage[2] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector3 sub(Vector3 arg) {
+  void sub(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] - argStorage[0];
     _v3storage[1] = _v3storage[1] - argStorage[1];
     _v3storage[2] = _v3storage[2] - argStorage[2];
-    return this;
   }
 
   /// Multiply entries in [this] with entries in [arg].
-  Vector3 multiply(Vector3 arg) {
+  void multiply(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] * argStorage[0];
     _v3storage[1] = _v3storage[1] * argStorage[1];
     _v3storage[2] = _v3storage[2] * argStorage[2];
-    return this;
   }
 
   /// Divide entries in [this] with entries in [arg].
-  Vector3 divide(Vector3 arg) {
+  void divide(Vector3 arg) {
     final argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] / argStorage[0];
     _v3storage[1] = _v3storage[1] / argStorage[1];
     _v3storage[2] = _v3storage[2] / argStorage[2];
-    return this;
   }
 
   /// Scale [this].
-  Vector3 scale(double arg) {
+  void scale(double arg) {
     _v3storage[2] = _v3storage[2] * arg;
     _v3storage[1] = _v3storage[1] * arg;
     _v3storage[0] = _v3storage[0] * arg;
-    return this;
   }
 
   /// Create a copy of [this] and scale it by [arg].
@@ -480,49 +463,44 @@ class Vector3 implements Vector {
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector3 clamp(Vector3 min, Vector3 max) {
+  void clamp(Vector3 min, Vector3 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
     _v3storage[0] = _v3storage[0].clamp(minStorage[0], maxStorage[0]);
     _v3storage[1] = _v3storage[1].clamp(minStorage[1], maxStorage[1]);
     _v3storage[2] = _v3storage[2].clamp(minStorage[2], maxStorage[2]);
-    return this;
   }
 
   /// Clamp entries in [this] in the range [min]-[max].
-  Vector3 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v3storage[0] = _v3storage[0].clamp(min, max);
     _v3storage[1] = _v3storage[1].clamp(min, max);
     _v3storage[2] = _v3storage[2].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector3 floor() {
+  void floor() {
     _v3storage[0] = _v3storage[0].floorToDouble();
     _v3storage[1] = _v3storage[1].floorToDouble();
     _v3storage[2] = _v3storage[2].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector3 ceil() {
+  void ceil() {
     _v3storage[0] = _v3storage[0].ceilToDouble();
     _v3storage[1] = _v3storage[1].ceilToDouble();
     _v3storage[2] = _v3storage[2].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector3 round() {
+  void round() {
     _v3storage[0] = _v3storage[0].roundToDouble();
     _v3storage[1] = _v3storage[1].roundToDouble();
     _v3storage[2] = _v3storage[2].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector3 roundToZero() {
+  void roundToZero() {
     _v3storage[0] = _v3storage[0] < 0.0
         ? _v3storage[0].ceilToDouble()
         : _v3storage[0].floorToDouble();
@@ -532,7 +510,6 @@ class Vector3 implements Vector {
     _v3storage[2] = _v3storage[2] < 0.0
         ? _v3storage[2].ceilToDouble()
         : _v3storage[2].floorToDouble();
-    return this;
   }
 
   /// Clone of [this].

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -65,49 +65,44 @@ class Vector4 implements Vector {
       : _v4storage = new Float64List.view(buffer, offset, 4);
 
   /// Set the values of the vector.
-  Vector4 setValues(double x_, double y_, double z_, double w_) {
+  void setValues(double x_, double y_, double z_, double w_) {
     _v4storage[3] = w_;
     _v4storage[2] = z_;
     _v4storage[1] = y_;
     _v4storage[0] = x_;
-    return this;
   }
 
   /// Zero the vector.
-  Vector4 setZero() {
+  void setZero() {
     _v4storage[0] = 0.0;
     _v4storage[1] = 0.0;
     _v4storage[2] = 0.0;
     _v4storage[3] = 0.0;
-    return this;
   }
 
   /// Set to the identity vector.
-  Vector4 setIdentity() {
+  void setIdentity() {
     _v4storage[0] = 0.0;
     _v4storage[1] = 0.0;
     _v4storage[2] = 0.0;
     _v4storage[3] = 1.0;
-    return this;
   }
 
   /// Set the values by copying them from [other].
-  Vector4 setFrom(Vector4 other) {
+  void setFrom(Vector4 other) {
     final otherStorage = other._v4storage;
     _v4storage[3] = otherStorage[3];
     _v4storage[2] = otherStorage[2];
     _v4storage[1] = otherStorage[1];
     _v4storage[0] = otherStorage[0];
-    return this;
   }
 
   /// Splat [arg] into all lanes of the vector.
-  Vector4 splat(double arg) {
+  void splat(double arg) {
     _v4storage[3] = arg;
     _v4storage[2] = arg;
     _v4storage[1] = arg;
     _v4storage[0] = arg;
-    return this;
   }
 
   /// Returns a printable string
@@ -177,22 +172,7 @@ class Vector4 implements Vector {
   }
 
   /// Normalizes [this].
-  Vector4 normalize() {
-    double l = length;
-    // TODO(johnmccutchan): Use an epsilon.
-    if (l == 0.0) {
-      return this;
-    }
-    l = 1.0 / l;
-    _v4storage[0] *= l;
-    _v4storage[1] *= l;
-    _v4storage[2] *= l;
-    _v4storage[3] *= l;
-    return this;
-  }
-
-  /// Normalizes [this]. Returns length of vector before normalization.
-  double normalizeLength() {
+  double normalize() {
     double l = length;
     if (l == 0.0) {
       return 0.0;
@@ -205,13 +185,20 @@ class Vector4 implements Vector {
     return l;
   }
 
+  /// Normalizes [this]. Returns length of vector before normalization.
+  /// DEPRCATED: Use [normalize].
+  @deprecated
+  double normalizeLength() => normalize();
+
   /// Normalizes copy of [this].
   Vector4 normalized() => clone()..normalize();
 
   /// Normalize vector into [out].
   Vector4 normalizeInto(Vector4 out) {
-    out.setFrom(this);
-    return out.normalize();
+    out
+      ..setFrom(this)
+      ..normalize();
+    return out;
   }
 
   /// Distance from [this] to [arg]
@@ -240,7 +227,7 @@ class Vector4 implements Vector {
   }
 
   /// Multiplies [this] by [arg].
-  Vector4 applyMatrix4(Matrix4 arg) {
+  void applyMatrix4(Matrix4 arg) {
     var v1 = _v4storage[0];
     var v2 = _v4storage[1];
     var v3 = _v4storage[2];
@@ -262,7 +249,6 @@ class Vector4 implements Vector {
         argStorage[7] * v2 +
         argStorage[11] * v3 +
         argStorage[15] * v4;
-    return this;
   }
 
   /// Relative error between [this] and [correct]
@@ -297,134 +283,121 @@ class Vector4 implements Vector {
     return is_nan;
   }
 
-  Vector4 add(Vector4 arg) {
+  void add(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] + argStorage[0];
     _v4storage[1] = _v4storage[1] + argStorage[1];
     _v4storage[2] = _v4storage[2] + argStorage[2];
     _v4storage[3] = _v4storage[3] + argStorage[3];
-    return this;
   }
 
   /// Add [arg] scaled by [factor] to [this].
-  Vector4 addScaled(Vector4 arg, double factor) {
+  void addScaled(Vector4 arg, double factor) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] + argStorage[0] * factor;
     _v4storage[1] = _v4storage[1] + argStorage[1] * factor;
     _v4storage[2] = _v4storage[2] + argStorage[2] * factor;
     _v4storage[3] = _v4storage[3] + argStorage[3] * factor;
-    return this;
   }
 
   /// Subtract [arg] from [this].
-  Vector4 sub(Vector4 arg) {
+  void sub(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] - argStorage[0];
     _v4storage[1] = _v4storage[1] - argStorage[1];
     _v4storage[2] = _v4storage[2] - argStorage[2];
     _v4storage[3] = _v4storage[3] - argStorage[3];
-    return this;
   }
 
   /// Multiply [this] by [arg].
-  Vector4 multiply(Vector4 arg) {
+  void multiply(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] * argStorage[0];
     _v4storage[1] = _v4storage[1] * argStorage[1];
     _v4storage[2] = _v4storage[2] * argStorage[2];
     _v4storage[3] = _v4storage[3] * argStorage[3];
-    return this;
   }
 
   /// Divide [this] by [arg].
-  Vector4 div(Vector4 arg) {
+  void div(Vector4 arg) {
     final argStorage = arg._v4storage;
     _v4storage[0] = _v4storage[0] / argStorage[0];
     _v4storage[1] = _v4storage[1] / argStorage[1];
     _v4storage[2] = _v4storage[2] / argStorage[2];
     _v4storage[3] = _v4storage[3] / argStorage[3];
-    return this;
   }
 
   /// Scale [this] by [arg].
-  Vector4 scale(double arg) {
+  void scale(double arg) {
     _v4storage[0] = _v4storage[0] * arg;
     _v4storage[1] = _v4storage[1] * arg;
     _v4storage[2] = _v4storage[2] * arg;
     _v4storage[3] = _v4storage[3] * arg;
-    return this;
   }
 
   /// Create a copy of [this] scaled by [arg].
   Vector4 scaled(double arg) => clone()..scale(arg);
 
   /// Negate [this].
-  Vector4 negate() {
+  void negate() {
     _v4storage[0] = -_v4storage[0];
     _v4storage[1] = -_v4storage[1];
     _v4storage[2] = -_v4storage[2];
     _v4storage[3] = -_v4storage[3];
-    return this;
   }
 
   /// Set [this] to the absolute.
-  Vector4 absolute() {
+  void absolute() {
     _v4storage[3] = _v4storage[3].abs();
     _v4storage[2] = _v4storage[2].abs();
     _v4storage[1] = _v4storage[1].abs();
     _v4storage[0] = _v4storage[0].abs();
-    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].
-  Vector4 clamp(Vector4 min, Vector4 max) {
+  void clamp(Vector4 min, Vector4 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
     _v4storage[0] = _v4storage[0].clamp(minStorage[0], maxStorage[0]);
     _v4storage[1] = _v4storage[1].clamp(minStorage[1], maxStorage[1]);
     _v4storage[2] = _v4storage[2].clamp(minStorage[2], maxStorage[2]);
     _v4storage[3] = _v4storage[3].clamp(minStorage[3], maxStorage[3]);
-    return this;
   }
 
   /// Clamp entries in [this] in the range [min]-[max].
-  Vector4 clampScalar(double min, double max) {
+  void clampScalar(double min, double max) {
     _v4storage[0] = _v4storage[0].clamp(min, max);
     _v4storage[1] = _v4storage[1].clamp(min, max);
     _v4storage[2] = _v4storage[2].clamp(min, max);
     _v4storage[3] = _v4storage[3].clamp(min, max);
-    return this;
   }
 
   /// Floor entries in [this].
-  Vector4 floor() {
+  void floor() {
     _v4storage[0] = _v4storage[0].floorToDouble();
     _v4storage[1] = _v4storage[1].floorToDouble();
     _v4storage[2] = _v4storage[2].floorToDouble();
     _v4storage[3] = _v4storage[3].floorToDouble();
-    return this;
   }
 
   /// Ceil entries in [this].
-  Vector4 ceil() {
+  void ceil() {
     _v4storage[0] = _v4storage[0].ceilToDouble();
     _v4storage[1] = _v4storage[1].ceilToDouble();
     _v4storage[2] = _v4storage[2].ceilToDouble();
     _v4storage[3] = _v4storage[3].ceilToDouble();
-    return this;
   }
 
   /// Round entries in [this].
-  Vector4 round() {
+  void round() {
     _v4storage[0] = _v4storage[0].roundToDouble();
     _v4storage[1] = _v4storage[1].roundToDouble();
     _v4storage[2] = _v4storage[2].roundToDouble();
     _v4storage[3] = _v4storage[3].roundToDouble();
-    return this;
   }
 
   /// Round entries in [this] towards zero.
-  Vector4 roundToZero() {
+  void roundToZero() {
     _v4storage[0] = _v4storage[0] < 0.0
         ? _v4storage[0].ceilToDouble()
         : _v4storage[0].floorToDouble();
@@ -437,7 +410,6 @@ class Vector4 implements Vector {
     _v4storage[3] = _v4storage[3] < 0.0
         ? _v4storage[3].ceilToDouble()
         : _v4storage[3].floorToDouble();
-    return this;
   }
 
   /// Create a copy of [this].

--- a/lib/src/vector_math_geometry/generators/attribute_generators.dart
+++ b/lib/src/vector_math_geometry/generators/attribute_generators.dart
@@ -32,19 +32,19 @@ void generateNormals(
 
     // Add the face normal to each vertex normal.
     normals.load(i0, norm);
-    normals[i0] = norm.add(p0);
+    normals[i0] = norm..add(p0);
 
     normals.load(i1, norm);
-    normals[i1] = norm.add(p0);
+    normals[i1] = norm..add(p0);
 
     normals.load(i2, norm);
-    normals[i2] = norm.add(p0);
+    normals[i2] = norm..add(p0);
   }
 
   // Loop through all the normals and normalize them.
   for (int i = 0; i < normals.length; ++i) {
     normals.load(i, norm);
-    normals[i] = norm.normalize();
+    normals[i] = norm..normalize();
   }
 }
 
@@ -104,32 +104,37 @@ void generateTangents(Vector4List tangents, Vector3List positions,
         (uv1.x * p2.y - uv2.x * p1.y) * r, (uv1.x * p2.z - uv2.x * p1.z) * r);
 
     tan0.load(i0, p0);
-    tan0[i0] = p0.add(udir);
+    tan0[i0] = p0..add(udir);
     tan0.load(i1, p0);
-    tan0[i1] = p0.add(udir);
+    tan0[i1] = p0..add(udir);
     tan0.load(i2, p0);
-    tan0[i2] = p0.add(udir);
+    tan0[i2] = p0..add(udir);
 
     tan1.load(i0, p0);
-    tan1[i0] = p0.add(vdir);
+    tan1[i0] = p0..add(vdir);
     tan1.load(i1, p0);
-    tan1[i1] = p0.add(vdir);
+    tan1[i1] = p0..add(vdir);
     tan1.load(i2, p0);
-    tan1[i2] = p0.add(vdir);
+    tan1[i2] = p0..add(vdir);
   }
 
   for (int i = 0; i < tangents.length; ++i) {
     normals.load(i, n);
     tan0.load(i, t);
 
-    p1.setFrom(n).scale(n.dot(t));
-    p0.setFrom(t).sub(p1).normalize();
+    p1
+      ..setFrom(n)
+      ..scale(n.dot(t));
+    p0
+      ..setFrom(t)
+      ..sub(p1)
+      ..normalize();
 
     tan1.load(i, p1);
     n.crossInto(t, p2);
     double sign = (p2.dot(p1) < 0.0) ? -1.0 : 1.0;
 
     tangents.load(i, tan);
-    tangents[i] = tan.setValues(p0.x, p0.y, p0.z, sign);
+    tangents[i] = tan..setValues(p0.x, p0.y, p0.z, sign);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 1.4.4-dev
+version: 2.0.0-dev
 author: John McCutchan <john@johnmccutchan.com>
 description: A Vector Math library for 2D and 3D applications.
 homepage: https://github.com/johnmccutchan/vector_math

--- a/test/aabb2_test.dart
+++ b/test/aabb2_test.dart
@@ -153,7 +153,7 @@ void testAabb2Rotate() {
   final rotation = new Matrix3.rotationZ(Math.PI / 4);
   final input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
 
-  final result = input.rotate(rotation);
+  final result = input..rotate(rotation);
 
   relativeTest(result.min.x, 2 - Math.sqrt(2));
   relativeTest(result.min.y, 2 - Math.sqrt(2));
@@ -167,7 +167,7 @@ void testAabb2Transform() {
   final rotation = new Matrix3.rotationZ(Math.PI / 4);
   final input = new Aabb2.minMax($v2(1.0, 1.0), $v2(3.0, 3.0));
 
-  final result = input.transform(rotation);
+  final result = input..transform(rotation);
   final newCenterY = Math.sqrt(8);
 
   relativeTest(result.min.x, -Math.sqrt(2));

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -367,7 +367,7 @@ void testMatrix4Translation() {
   inputA.add(new Matrix4.identity());
   inputB.add(new Matrix4.translationValues(1.0, 3.0, 5.7));
   output1.add(inputA[0] * inputB[0]);
-  output2.add((new Matrix4.identity()).translate(1.0, 3.0, 5.7));
+  output2.add((new Matrix4.identity())..translate(1.0, 3.0, 5.7));
 
   assert(inputA.length == inputB.length);
   assert(output1.length == output2.length);
@@ -386,7 +386,7 @@ void testMatrix4Scale() {
   inputA.add(new Matrix4.identity());
   inputB.add(new Matrix4.diagonal3Values(1.0, 3.0, 5.7));
   output1.add(inputA[0] * inputB[0]);
-  output2.add(new Matrix4.identity().scale(1.0, 3.0, 5.7));
+  output2.add(new Matrix4.identity()..scale(1.0, 3.0, 5.7));
 
   assert(inputA.length == inputB.length);
   assert(output1.length == output2.length);
@@ -400,11 +400,11 @@ void testMatrix4Rotate() {
   var output1 = new List();
   var output2 = new List();
   output1.add(new Matrix4.rotationX(1.57079632679));
-  output2.add(new Matrix4.identity().rotateX(1.57079632679));
+  output2.add(new Matrix4.identity()..rotateX(1.57079632679));
   output1.add(new Matrix4.rotationY(1.57079632679 * 0.5));
-  output2.add(new Matrix4.identity().rotateY(1.57079632679 * 0.5));
+  output2.add(new Matrix4.identity()..rotateY(1.57079632679 * 0.5));
   output1.add(new Matrix4.rotationZ(1.57079632679 * 0.25));
-  output2.add(new Matrix4.identity().rotateZ(1.57079632679 * 0.25));
+  output2.add(new Matrix4.identity()..rotateZ(1.57079632679 * 0.25));
   {
     var axis = new Vector3(1.1, 1.1, 1.1);
     axis.normalize();
@@ -416,7 +416,7 @@ void testMatrix4Rotate() {
     T.setRotation(R);
     output1.add(T);
 
-    output2.add(new Matrix4.identity().rotate(axis, angle));
+    output2.add(new Matrix4.identity()..rotate(axis, angle));
   }
   assert(output1.length == output2.length);
   for (int i = 0; i < output1.length; i++) {

--- a/test/quaternion_test.dart
+++ b/test/quaternion_test.dart
@@ -45,7 +45,7 @@ void testQuaternionInstacingFromByteBuffer() {
 void testConjugate(List<Quaternion> input, List<Quaternion> expectedOutput) {
   assert(input.length == expectedOutput.length);
   for (int i = 0; i < input.length; i++) {
-    Quaternion output = input[i].conjugate();
+    Quaternion output = input[i]..conjugate();
     relativeTest(output, expectedOutput[i]);
   }
 }
@@ -90,14 +90,14 @@ void testQuaternionConjugate() {
 
 void testQuaternionMatrixQuaternionRoundTrip() {
   List<Quaternion> input = new List<Quaternion>();
-  input.add(new Quaternion.identity().normalize());
-  input.add(new Quaternion(0.18260, 0.54770, 0.73030, 0.36510).normalize());
-  input.add(new Quaternion(0.9889, 0.0, 0.0, 0.14834).normalize());
+  input.add(new Quaternion.identity()..normalize());
+  input.add(new Quaternion(0.18260, 0.54770, 0.73030, 0.36510)..normalize());
+  input.add(new Quaternion(0.9889, 0.0, 0.0, 0.14834)..normalize());
   input.add(
-      new Quaternion(0.388127, 0.803418, -0.433317, -0.126429).normalize());
-  input.add(new Quaternion(1.0, 0.0, 0.0, 1.0).normalize());
-  input.add(new Quaternion(0.0, 1.0, 0.0, 1.0).normalize());
-  input.add(new Quaternion(0.0, 0.0, 1.0, 1.0).normalize());
+      new Quaternion(0.388127, 0.803418, -0.433317, -0.126429)..normalize());
+  input.add(new Quaternion(1.0, 0.0, 0.0, 1.0)..normalize());
+  input.add(new Quaternion(0.0, 1.0, 0.0, 1.0)..normalize());
+  input.add(new Quaternion(0.0, 0.0, 1.0, 1.0)..normalize());
   testQuaternionMatrixRoundTrip(input);
 }
 
@@ -119,56 +119,56 @@ void testQuaternionNormalize() {
   List<Vector3> inputB = new List<Vector3>();
   List<Vector3> expectedOutput = new List<Vector3>();
 
-  inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0).normalize());
+  inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0)..normalize());
   inputB.add(new Vector3(1.0, 1.0, 1.0));
   expectedOutput.add(new Vector3(-1.0, 1.0, 1.0));
 
-  inputA.add(new Quaternion.identity().normalize());
+  inputA.add(new Quaternion.identity()..normalize());
   inputB.add(new Vector3(1.0, 2.0, 3.0));
   expectedOutput.add(new Vector3(1.0, 2.0, 3.0));
 
-  inputA.add(new Quaternion(0.18260, 0.54770, 0.73030, 0.36510).normalize());
+  inputA.add(new Quaternion(0.18260, 0.54770, 0.73030, 0.36510)..normalize());
   inputB.add(new Vector3(1.0, 0.0, 0.0));
   expectedOutput.add(new Vector3(-0.6667, -0.3333, 0.6667));
 
   {
-    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(1.0, 0.0, 0.0));
     expectedOutput.add(new Vector3(1.0, 0.0, 0.0));
 
-    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 1.0, 0.0));
     expectedOutput.add(new Vector3(0.0, 0.0, -1.0));
 
-    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(1.0, 0.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 0.0, 1.0));
     expectedOutput.add(new Vector3(0.0, 1.0, 0.0));
   }
 
   {
-    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(1.0, 0.0, 0.0));
     expectedOutput.add(new Vector3(0.0, 0.0, 1.0));
 
-    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 1.0, 0.0));
     expectedOutput.add(new Vector3(0.0, 1.0, 0.0));
 
-    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 1.0, 0.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 0.0, 1.0));
     expectedOutput.add(new Vector3(-1.0, 0.0, 0.0));
   }
 
   {
-    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0)..normalize());
     inputB.add(new Vector3(1.0, 0.0, 0.0));
     expectedOutput.add(new Vector3(0.0, -1.0, 0.0));
 
-    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 1.0, 0.0));
     expectedOutput.add(new Vector3(1.0, 0.0, 0.0));
 
-    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0).normalize());
+    inputA.add(new Quaternion(0.0, 0.0, 1.0, 1.0)..normalize());
     inputB.add(new Vector3(0.0, 0.0, 1.0));
     expectedOutput.add(new Vector3(0.0, 0.0, 1.0));
   }

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -98,7 +98,7 @@ void testVector2Postmultiplication() {
   // print("input $inputInv");
   Vector2 resultOld = inputMatrix.transposed() * inputVector;
   Vector2 resultOldvInv = inputInv * inputVector;
-  Vector2 resultNew = inputVector.postmultiply(inputMatrix);
+  Vector2 resultNew = inputVector..postmultiply(inputMatrix);
   expect(resultNew.x, equals(resultOld.x));
   expect(resultNew.y, equals(resultOld.y));
   //matrix inversion can introduce a small error
@@ -152,7 +152,7 @@ void testVector2Length() {
   relativeTest(a.length, 8.6);
   relativeTest(a.length2, 74.0);
 
-  relativeTest(a.normalizeLength(), 8.6);
+  relativeTest(a.normalize(), 8.6);
   relativeTest(a.x, 0.5812);
   relativeTest(a.y, 0.8137);
 }

--- a/test/vector3_test.dart
+++ b/test/vector3_test.dart
@@ -122,7 +122,7 @@ void testVector3Postmultiplication() {
   inputInv.invert();
   Vector3 resultOld = inputMatrix.transposed() * inputVector;
   Vector3 resultOldvInv = inputInv * inputVector;
-  Vector3 resultNew = inputVector.postmultiply(inputMatrix);
+  Vector3 resultNew = inputVector..postmultiply(inputMatrix);
 
   expect(resultNew.x, equals(resultOld.x));
   expect(resultNew.y, equals(resultOld.y));
@@ -207,7 +207,7 @@ void testVector3Length() {
   relativeTest(a.length, 9.1104);
   relativeTest(a.length2, 83.0);
 
-  relativeTest(a.normalizeLength(), 9.1104);
+  relativeTest(a.normalize(), 9.1104);
   relativeTest(a.x, 0.5488);
   relativeTest(a.y, 0.7683);
   relativeTest(a.z, 0.3292);

--- a/test/vector4_test.dart
+++ b/test/vector4_test.dart
@@ -121,7 +121,7 @@ void testVector4Length() {
   relativeTest(a.length, 13.5277);
   relativeTest(a.length2, 183.0);
 
-  relativeTest(a.normalizeLength(), 13.5277);
+  relativeTest(a.normalize(), 13.5277);
   relativeTest(a.x, 0.3696);
   relativeTest(a.y, 0.5174);
   relativeTest(a.z, 0.2217);


### PR DESCRIPTION
This removes call chaining as Dart comes with the ```..``` chaining operator as discussed in #59.
This allows us to use the return value for other things, like in normalize. Deprecate normalizeLength as it is now the same as normalize.
This is a (big) breaking change, therefore I bumped the version number to 2.0.0-dev

Maybe we even want to release a version on pub before this?