### PR TITLE
Revert inconsistencies with Vector3

### DIFF
--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -472,17 +472,19 @@ class Vector3 implements Vector {
   Vector3 scaled(double arg) => clone()..scale(arg);
 
   /// Negate [this].
-  void negate() {
+  Vector3 negate() {
     _v3storage[2] = -_v3storage[2];
     _v3storage[1] = -_v3storage[1];
     _v3storage[0] = -_v3storage[0];
+    return this;
   }
 
   /// Absolute value.
-  void absolute() {
+  Vector3 absolute() {
     _v3storage[0] = _v3storage[0].abs();
     _v3storage[1] = _v3storage[1].abs();
     _v3storage[2] = _v3storage[2].abs();
+    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -472,17 +472,19 @@ class Vector3 implements Vector {
   Vector3 scaled(double arg) => clone()..scale(arg);
 
   /// Negate [this].
-  void negate() {
+  Vector3 negate() {
     _v3storage[2] = -_v3storage[2];
     _v3storage[1] = -_v3storage[1];
     _v3storage[0] = -_v3storage[0];
+    return this;
   }
 
   /// Absolute value.
-  void absolute() {
+  Vector3 absolute() {
     _v3storage[0] = _v3storage[0].abs();
     _v3storage[1] = _v3storage[1].abs();
     _v3storage[2] = _v3storage[2].abs();
+    return this;
   }
 
   /// Clamp each entry n in [this] in the range [min[n]]-[max[n]].


### PR DESCRIPTION
We want to stop returning 'this' for these types of operations, but we want to do it
all at once across all classes.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/vector_math.dart/145)
<!-- Reviewable:end -->
