### PR TITLE
Equals operator for matrixN classes

### DIFF
--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -136,11 +136,24 @@ class Matrix2 {
   /// Dimension of the matrix.
   int get dimension => 2;
 
+  /// Access the element of the matrix at the index [i].
   double operator [](int i) => _m2storage[i];
 
+  /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
     _m2storage[i] = v;
   }
+
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix2) &&
+        (_m2storage[0] == other._m2storage[0]) &&
+        (_m2storage[1] == other._m2storage[1]) &&
+        (_m2storage[2] == other._m2storage[2]) &&
+        (_m2storage[3] == other._m2storage[3]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m2storage);
 
   /// Returns row 0
   Vector2 get row0 => getRow(0);

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -234,6 +234,22 @@ class Matrix3 {
     _m3storage[i] = v;
   }
 
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix3) &&
+        (_m3storage[0] == other._m3storage[0]) &&
+        (_m3storage[1] == other._m3storage[1]) &&
+        (_m3storage[2] == other._m3storage[2]) &&
+        (_m3storage[3] == other._m3storage[3]) &&
+        (_m3storage[4] == other._m3storage[4]) &&
+        (_m3storage[5] == other._m3storage[5]) &&
+        (_m3storage[6] == other._m3storage[6]) &&
+        (_m3storage[7] == other._m3storage[7]) &&
+        (_m3storage[8] == other._m3storage[8]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m3storage);
+
   /// Returns row 0
   Vector3 get row0 => getRow(0);
 

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -429,11 +429,36 @@ class Matrix4 {
   /// Dimension of the matrix.
   int get dimension => 4;
 
+  /// Access the element of the matrix at the index [i].
   double operator [](int i) => _m4storage[i];
 
+  /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
     _m4storage[i] = v;
   }
+
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix4) &&
+        (_m4storage[0] == other._m4storage[0]) &&
+        (_m4storage[1] == other._m4storage[1]) &&
+        (_m4storage[2] == other._m4storage[2]) &&
+        (_m4storage[3] == other._m4storage[3]) &&
+        (_m4storage[4] == other._m4storage[4]) &&
+        (_m4storage[5] == other._m4storage[5]) &&
+        (_m4storage[6] == other._m4storage[6]) &&
+        (_m4storage[7] == other._m4storage[7]) &&
+        (_m4storage[8] == other._m4storage[8]) &&
+        (_m4storage[9] == other._m4storage[9]) &&
+        (_m4storage[10] == other._m4storage[10]) &&
+        (_m4storage[11] == other._m4storage[11]) &&
+        (_m4storage[12] == other._m4storage[12]) &&
+        (_m4storage[13] == other._m4storage[13]) &&
+        (_m4storage[14] == other._m4storage[14]) &&
+        (_m4storage[15] == other._m4storage[15]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m4storage);
 
   /// Returns row 0
   Vector4 get row0 => getRow(0);

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -87,8 +87,9 @@ class Vector2 implements Vector {
   String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector2 other) {
-    return (_v2storage[0] == other._v2storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector2) &&
+        (_v2storage[0] == other._v2storage[0]) &&
         (_v2storage[1] == other._v2storage[1]);
   }
 

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -93,6 +93,8 @@ class Vector2 implements Vector {
         (_v2storage[1] == other._v2storage[1]);
   }
 
+  int get hashCode => quiver.hashObjects(_v2storage);
+
   /// Negate.
   Vector2 operator -() => clone()..negate();
 

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -95,8 +95,9 @@ class Vector3 implements Vector {
   String toString() => '[${storage[0]},${storage[1]},${storage[2]}]';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector3 other) {
-    return (_v3storage[0] == other._v3storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector3) &&
+        (_v3storage[0] == other._v3storage[0]) &&
         (_v3storage[1] == other._v3storage[1]) &&
         (_v3storage[2] == other._v3storage[2]);
   }

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -102,6 +102,8 @@ class Vector3 implements Vector {
         (_v3storage[2] == other._v3storage[2]);
   }
 
+  int get hashCode => quiver.hashObjects(_v3storage);
+
   /// Negate
   Vector3 operator -() => clone()..negate();
 

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -115,8 +115,9 @@ class Vector4 implements Vector {
       '${_v4storage[2]},${_v4storage[3]}';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector4 other) {
-    return (_v4storage[0] == other._v4storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector4) &&
+        (_v4storage[0] == other._v4storage[0]) &&
         (_v4storage[1] == other._v4storage[1]) &&
         (_v4storage[2] == other._v4storage[2]) &&
         (_v4storage[3] == other._v4storage[3]);

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -123,6 +123,8 @@ class Vector4 implements Vector {
         (_v4storage[3] == other._v4storage[3]);
   }
 
+  int get hashCode => quiver.hashObjects(_v4storage);
+
   /// Negate.
   Vector4 operator -() => clone()..negate();
 

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -136,11 +136,24 @@ class Matrix2 {
   /// Dimension of the matrix.
   int get dimension => 2;
 
+  /// Access the element of the matrix at the index [i].
   double operator [](int i) => _m2storage[i];
 
+  /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
     _m2storage[i] = v;
   }
+
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix2) &&
+        (_m2storage[0] == other._m2storage[0]) &&
+        (_m2storage[1] == other._m2storage[1]) &&
+        (_m2storage[2] == other._m2storage[2]) &&
+        (_m2storage[3] == other._m2storage[3]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m2storage);
 
   /// Returns row 0
   Vector2 get row0 => getRow(0);

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -234,6 +234,22 @@ class Matrix3 {
     _m3storage[i] = v;
   }
 
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix3) &&
+        (_m3storage[0] == other._m3storage[0]) &&
+        (_m3storage[1] == other._m3storage[1]) &&
+        (_m3storage[2] == other._m3storage[2]) &&
+        (_m3storage[3] == other._m3storage[3]) &&
+        (_m3storage[4] == other._m3storage[4]) &&
+        (_m3storage[5] == other._m3storage[5]) &&
+        (_m3storage[6] == other._m3storage[6]) &&
+        (_m3storage[7] == other._m3storage[7]) &&
+        (_m3storage[8] == other._m3storage[8]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m3storage);
+
   /// Returns row 0
   Vector3 get row0 => getRow(0);
 

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -429,11 +429,36 @@ class Matrix4 {
   /// Dimension of the matrix.
   int get dimension => 4;
 
+  /// Access the element of the matrix at the index [i].
   double operator [](int i) => _m4storage[i];
 
+  /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
     _m4storage[i] = v;
   }
+
+  /// Check if two matrices are the same.
+  bool operator ==(other) {
+    return (other is Matrix4) &&
+        (_m4storage[0] == other._m4storage[0]) &&
+        (_m4storage[1] == other._m4storage[1]) &&
+        (_m4storage[2] == other._m4storage[2]) &&
+        (_m4storage[3] == other._m4storage[3]) &&
+        (_m4storage[4] == other._m4storage[4]) &&
+        (_m4storage[5] == other._m4storage[5]) &&
+        (_m4storage[6] == other._m4storage[6]) &&
+        (_m4storage[7] == other._m4storage[7]) &&
+        (_m4storage[8] == other._m4storage[8]) &&
+        (_m4storage[9] == other._m4storage[9]) &&
+        (_m4storage[10] == other._m4storage[10]) &&
+        (_m4storage[11] == other._m4storage[11]) &&
+        (_m4storage[12] == other._m4storage[12]) &&
+        (_m4storage[13] == other._m4storage[13]) &&
+        (_m4storage[14] == other._m4storage[14]) &&
+        (_m4storage[15] == other._m4storage[15]);
+  }
+
+  int get hashCode => quiver.hashObjects(_m4storage);
 
   /// Returns row 0
   Vector4 get row0 => getRow(0);

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -87,10 +87,13 @@ class Vector2 implements Vector {
   String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector2 other) {
-    return (_v2storage[0] == other._v2storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector2) &&
+        (_v2storage[0] == other._v2storage[0]) &&
         (_v2storage[1] == other._v2storage[1]);
   }
+
+  int get hashCode => quiver.hashObjects(_v2storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -95,11 +95,14 @@ class Vector3 implements Vector {
   String toString() => '[${storage[0]},${storage[1]},${storage[2]}]';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector3 other) {
-    return (_v3storage[0] == other._v3storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector3) &&
+        (_v3storage[0] == other._v3storage[0]) &&
         (_v3storage[1] == other._v3storage[1]) &&
         (_v3storage[2] == other._v3storage[2]);
   }
+
+  int get hashCode => quiver.hashObjects(_v3storage);
 
   /// Negate
   Vector3 operator -() => clone()..negate();

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -115,12 +115,15 @@ class Vector4 implements Vector {
       '${_v4storage[2]},${_v4storage[3]}';
 
   /// Check if two vectors are the same.
-  bool operator ==(Vector4 other) {
-    return (_v4storage[0] == other._v4storage[0]) &&
+  bool operator ==(other) {
+    return (other is Vector4) &&
+        (_v4storage[0] == other._v4storage[0]) &&
         (_v4storage[1] == other._v4storage[1]) &&
         (_v4storage[2] == other._v4storage[2]) &&
         (_v4storage[3] == other._v4storage[3]);
   }
+
+  int get hashCode => quiver.hashObjects(_v4storage);
 
   /// Negate.
   Vector4 operator -() => clone()..negate();

--- a/lib/vector_math.dart
+++ b/lib/vector_math.dart
@@ -21,6 +21,7 @@ library vector_math;
 
 import 'dart:typed_data';
 import 'dart:math' as Math;
+import 'package:quiver/core.dart' as quiver;
 
 part 'src/vector_math/utilities.dart';
 part 'src/vector_math/aabb2.dart';

--- a/lib/vector_math_64.dart
+++ b/lib/vector_math_64.dart
@@ -21,6 +21,7 @@ library vector_math_64;
 
 import 'dart:typed_data';
 import 'dart:math' as Math;
+import 'package:quiver/core.dart' as quiver;
 
 part 'src/vector_math_64/utilities.dart';
 part 'src/vector_math_64/aabb2.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,8 @@ description: A Vector Math library for 2D and 3D applications.
 homepage: https://github.com/google/vector_math.dart
 environment:
   sdk: '>=1.0.0 <2.0.0'
+dependencies:
+  quiver: '>=0.19.0 <0.23.0'
 dev_dependencies:
   benchmark_harness: any
   browser: any

--- a/test/matrix2_test.dart
+++ b/test/matrix2_test.dart
@@ -112,6 +112,14 @@ void testMatrix2Solving() {
   expect(backwards.y, equals(b.y));
 }
 
+void testMatrix2Equals() {
+  expect(new Matrix2.identity(), equals(new Matrix2.identity()));
+  expect(new Matrix2.zero(), isNot(equals(new Matrix2.identity())));
+  expect(new Matrix2.zero(), isNot(equals(5)));
+  expect(
+      new Matrix2.identity().hashCode, equals(new Matrix2.identity().hashCode));
+}
+
 void main() {
   group('Matrix2', () {
     test('Determinant', testMatrix2Determinant);
@@ -121,5 +129,6 @@ void main() {
     test('dot product', testMatrix2Dot);
     test('Scale', testMatrix2Scale);
     test('solving', testMatrix2Solving);
+    test('equals', testMatrix2Equals);
   });
 }

--- a/test/matrix3_test.dart
+++ b/test/matrix3_test.dart
@@ -310,6 +310,14 @@ void testMatrix3Solving() {
   expect(backwards2.y, equals(b2.y));
 }
 
+void testMatrix3Equals() {
+  expect(new Matrix3.identity(), equals(new Matrix3.identity()));
+  expect(new Matrix3.zero(), isNot(equals(new Matrix3.identity())));
+  expect(new Matrix3.zero(), isNot(equals(5)));
+  expect(
+      new Matrix3.identity().hashCode, equals(new Matrix3.identity().hashCode));
+}
+
 void main() {
   group('Matrix3', () {
     test('Determinant', testMatrix3Determinant);
@@ -325,5 +333,6 @@ void main() {
     test('dot product', testMatrix3Dot);
     test('Scale', testMatrix3Scale);
     test('solving', testMatrix3Solving);
+    test('equals', testMatrix3Equals);
   });
 }

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -589,6 +589,14 @@ void testMatrix4Compose() {
   }
 }
 
+void testMatrix4Equals() {
+  expect(new Matrix4.identity(), equals(new Matrix4.identity()));
+  expect(new Matrix4.zero(), isNot(equals(new Matrix4.identity())));
+  expect(new Matrix4.zero(), isNot(equals(5)));
+  expect(
+      new Matrix4.identity().hashCode, equals(new Matrix4.identity().hashCode));
+}
+
 void main() {
   group('Matrix4', () {
     test('instancing from Float32List', testMatrix4InstacingFromFloat32List);
@@ -611,5 +619,6 @@ void main() {
     test('perspective transform', testMatrix4PerspectiveTransform);
     test('solving', testMatrix4Solving);
     test('compose/decompose', testMatrix4Compose);
+    test('equals', testMatrix4Equals);
   });
 }

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -192,6 +192,8 @@ void testVector2Equals() {
   expect(v2 == new Vector2(1.0, 2.0), isTrue);
   expect(v2 == new Vector2(1.0, 0.0), isFalse);
   expect(v2 == new Vector2(0.0, 2.0), isFalse);
+  expect(
+      new Vector2(1.0, 2.0).hashCode, equals(new Vector2(1.0, 2.0).hashCode));
 }
 
 void testVector2Reflect() {

--- a/test/vector3_test.dart
+++ b/test/vector3_test.dart
@@ -253,6 +253,8 @@ void testVector3Equals() {
   expect(v3 == new Vector3(0.0, 2.0, 3.0), isFalse);
   expect(v3 == new Vector3(1.0, 0.0, 3.0), isFalse);
   expect(v3 == new Vector3(1.0, 2.0, 0.0), isFalse);
+  expect(new Vector3(1.0, 2.0, 3.0).hashCode,
+      equals(new Vector3(1.0, 2.0, 3.0).hashCode));
 }
 
 void testVector3Reflect() {

--- a/test/vector4_test.dart
+++ b/test/vector4_test.dart
@@ -169,6 +169,8 @@ void testVector4Equals() {
   expect(v4 == new Vector4(1.0, 0.0, 3.0, 4.0), isFalse);
   expect(v4 == new Vector4(1.0, 2.0, 0.0, 4.0), isFalse);
   expect(v4 == new Vector4(1.0, 2.0, 3.0, 0.0), isFalse);
+  expect(new Vector4(1.0, 2.0, 3.0, 4.0).hashCode,
+      equals(new Vector4(1.0, 2.0, 3.0, 4.0).hashCode));
 }
 
 void testVector4DistanceTo() {


### PR DESCRIPTION
As requested in #147

First I fixed the equals operator implementation of the `VectorN` classes. When comparing with instances from other types they would crash instead of returning false as expected. [From the Dart Object == operator doc: "Total: It must return a boolean for all arguments. It should never throw or return null."](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:core.Object#id_==)
Afterwards I implemented the equals operator for the `MatrixN` classes and the corresponding tests.

We should also implement `hashCode` to maintain consistency. We could use [quivers hash helpers](https://github.com/google/quiver-dart/blob/master/lib/src/core/hash.dart#L20) here, but that would add a new dependency. Should I also include this change in the PR?
