### PR TITLE
Quaternion bug fix + construction from two vectors

### DIFF
--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -255,7 +255,13 @@ class Quaternion {
 
   /// [axis] of rotation.
   Vector3 get axis {
-    final scale = 1.0 / (1.0 - (_qStorage[3] * _qStorage[3]));
+    final den = 1.0 - (_qStorage[3] * _qStorage[3]);
+    if (den < 0.0005) {
+      // 0-angle rotation, so axis does not matter
+      return new Vector3.zero();
+    }
+
+    final scale = 1.0 / Math.sqrt(den);
     return new Vector3(
         _qStorage[0] * scale, _qStorage[1] * scale, _qStorage[2] * scale);
   }

--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -51,6 +51,10 @@ class Quaternion {
   factory Quaternion.axisAngle(Vector3 axis, double angle) =>
       new Quaternion._()..setAxisAngle(axis, angle);
 
+  /// Constructs a quaternion to be the rotation that rotates vector [a] to [b].
+  factory Quaternion.fromTwoVectors(Vector3 a, Vector3 b) =>
+      new Quaternion._()..setFromTwoVectors(a, b);
+
   /// Constructs a quaternion as a copy of [original].
   factory Quaternion.copy(Quaternion original) =>
       new Quaternion._()..setFrom(original);
@@ -148,6 +152,37 @@ class Quaternion {
               rotationMatrixStorage[rotationMatrix.index(i, k)]) *
           s;
     }
+  }
+
+  void setFromTwoVectors(Vector3 a, Vector3 b) {
+    Vector3 v1 = a.normalized();
+    Vector3 v2 = b.normalized();
+
+    double c = v1.dot(v2);
+    double angle = Math.acos(c);
+    Vector3 axis = v1.cross(v2);
+
+    if ((1.0 + c).abs() < 0.0005) {
+      // c \approx -1 indicates 180 degree rotation
+      angle = Math.PI;
+
+      // a and b are parallel in opposite directions. We need any
+      // vector as our rotation axis that is perpendicular.
+      // Find one by taking the cross product of v1 with an appropriate unit axis
+      if (v1.x > v1.y && v1.x > v1.z) {
+        // v1 points in a dominantly x direction, so don't cross with that axis
+        axis = v1.cross(new Vector3(0.0, 1.0, 0.0));
+      } else {
+        // Predominantly points in some other direction, so x-axis should be safe
+        axis = v1.cross(new Vector3(1.0, 0.0, 0.0));
+      }
+    } else if ((1.0 - c).abs() < 0.0005) {
+      // c \approx 1 is 0-degree rotation, axis is arbitrary
+      angle = 0.0;
+      axis = new Vector3(1.0, 0.0, 0.0);
+    }
+
+    setAxisAngle(axis.normalized(), angle);
   }
 
   /// Set the quaternion to a random rotation. The random number generator [rn]

--- a/lib/src/vector_math_64/quaternion.dart
+++ b/lib/src/vector_math_64/quaternion.dart
@@ -255,7 +255,13 @@ class Quaternion {
 
   /// [axis] of rotation.
   Vector3 get axis {
-    final scale = 1.0 / (1.0 - (_qStorage[3] * _qStorage[3]));
+    final den = 1.0 - (_qStorage[3] * _qStorage[3]);
+    if (den < 0.0005) {
+      // 0-angle rotation, so axis does not matter
+      return new Vector3.zero();
+    }
+
+    final scale = 1.0 / Math.sqrt(den);
     return new Vector3(
         _qStorage[0] * scale, _qStorage[1] * scale, _qStorage[2] * scale);
   }

--- a/lib/src/vector_math_64/quaternion.dart
+++ b/lib/src/vector_math_64/quaternion.dart
@@ -51,6 +51,10 @@ class Quaternion {
   factory Quaternion.axisAngle(Vector3 axis, double angle) =>
       new Quaternion._()..setAxisAngle(axis, angle);
 
+  /// Constructs a quaternion to be the rotation that rotates vector [a] to [b].
+  factory Quaternion.fromTwoVectors(Vector3 a, Vector3 b) =>
+      new Quaternion._()..setFromTwoVectors(a, b);
+
   /// Constructs a quaternion as a copy of [original].
   factory Quaternion.copy(Quaternion original) =>
       new Quaternion._()..setFrom(original);
@@ -148,6 +152,37 @@ class Quaternion {
               rotationMatrixStorage[rotationMatrix.index(i, k)]) *
           s;
     }
+  }
+
+  void setFromTwoVectors(Vector3 a, Vector3 b) {
+    Vector3 v1 = a.normalized();
+    Vector3 v2 = b.normalized();
+
+    double c = v1.dot(v2);
+    double angle = Math.acos(c);
+    Vector3 axis = v1.cross(v2);
+
+    if ((1.0 + c).abs() < 0.0005) {
+      // c \approx -1 indicates 180 degree rotation
+      angle = Math.PI;
+
+      // a and b are parallel in opposite directions. We need any
+      // vector as our rotation axis that is perpendicular.
+      // Find one by taking the cross product of v1 with an appropriate unit axis
+      if (v1.x > v1.y && v1.x > v1.z) {
+        // v1 points in a dominantly x direction, so don't cross with that axis
+        axis = v1.cross(new Vector3(0.0, 1.0, 0.0));
+      } else {
+        // Predominantly points in some other direction, so x-axis should be safe
+        axis = v1.cross(new Vector3(1.0, 0.0, 0.0));
+      }
+    } else if ((1.0 - c).abs() < 0.0005) {
+      // c \approx 1 is 0-degree rotation, axis is arbitrary
+      angle = 0.0;
+      axis = new Vector3(1.0, 0.0, 0.0);
+    }
+
+    setAxisAngle(axis.normalized(), angle);
   }
 
   /// Set the quaternion to a random rotation. The random number generator [rn]

--- a/test/quaternion_test.dart
+++ b/test/quaternion_test.dart
@@ -192,6 +192,32 @@ void testQuaternionAxisAngle() {
   }
 }
 
+void testFromTwoVectors() {
+  {
+    // "Normal" test case
+    Vector3 a = new Vector3(1.0, 0.0, 0.0);
+    Vector3 b = new Vector3(0.0, 1.0, 0.0);
+    Quaternion q = new Quaternion.fromTwoVectors(a, b);
+    relativeTest(q.radians, 0.5 * Math.PI);
+    relativeTest(q.axis, new Vector3(0.0, 0.0, 1.0));
+  }
+  {
+    // Degenerate null rotation
+    Vector3 a = new Vector3(1.0, 0.0, 0.0);
+    Vector3 b = new Vector3(1.0, 0.0, 0.0);
+    Quaternion q = new Quaternion.fromTwoVectors(a, b);
+    relativeTest(q.radians, 0.0);
+    // Axis can be arbitrary
+  }
+  {
+    // Parallel vectors in opposite direction
+    Vector3 a = new Vector3(1.0, 0.0, 0.0);
+    Vector3 b = new Vector3(-1.0, 0.0, 0.0);
+    Quaternion q = new Quaternion.fromTwoVectors(a, b);
+    relativeTest(q.radians, Math.PI);
+  }
+}
+
 void main() {
   group('Quaternion', () {
     test('Float32List instacing', testQuaternionInstacingFromByteBuffer);
@@ -202,5 +228,6 @@ void main() {
     test('Multiply', testQuaternionMultiplying);
     test('Normalize', testQuaternionNormalize);
     test('Axis-Angle', testQuaternionAxisAngle);
+    test('Construction from two vectors', testFromTwoVectors);
   });
 }

--- a/test/quaternion_test.dart
+++ b/test/quaternion_test.dart
@@ -5,6 +5,7 @@
 library vector_math.test.quaternion_test;
 
 import 'dart:typed_data';
+import 'dart:math' as Math;
 
 import 'package:test/test.dart';
 
@@ -176,6 +177,21 @@ void testQuaternionNormalize() {
   testQuaternionVectorRotate(inputA, inputB, expectedOutput);
 }
 
+void testQuaternionAxisAngle() {
+  // Test conversion to and from axis-angle representation
+  {
+    Quaternion q = new Quaternion.axisAngle(new Vector3(0.0, 1.0, 0.0), 0.5 * Math.PI);
+    relativeTest(q.radians, 0.5 * Math.PI);
+    relativeTest(q.axis, new Vector3(0.0, 1.0, 0.0));
+  }
+
+  {
+    // Degenerate test: 0-angle
+    Quaternion q = new Quaternion.axisAngle(new Vector3(1.0, 0.0, 0.0), 0.0);
+    relativeTest(q.radians, 0.0);
+  }
+}
+
 void main() {
   group('Quaternion', () {
     test('Float32List instacing', testQuaternionInstacingFromByteBuffer);
@@ -185,5 +201,6 @@ void main() {
         testQuaternionMatrixQuaternionRoundTrip);
     test('Multiply', testQuaternionMultiplying);
     test('Normalize', testQuaternionNormalize);
+    test('Axis-Angle', testQuaternionAxisAngle);
   });
 }


### PR DESCRIPTION
Two (small) changes in here:

- Bug fix in how axes are extracted from Quaternions. The denominator of the scaling factor should have a square root, otherwise it won't return the input axis for rotations != PI. I also changed it to check for a degenerate denominator (from a 0 rotation) to prevent blow-up.

- New factory to construct a Quat from two vectors. Pretty common operation. Also checks for the edge cases (0 rotation and PI rotation).

I also added tests for both.