### PR TITLE
Vector.angleTo and angleToSigned

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 # Changelog - vector_math
 
-## v 2.0.2 - Unreleased
+## v 2.0.3 - Unreleased
+
+## v 2.0.2 - April 2016
+
+- Add Vector2.angleTo and .angleToSigned
 
 ## v 2.0.1 - April 2016
 

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -154,7 +154,7 @@ class Vector2 implements Vector {
   }
 
   /// Normalize [this]. Returns length of vector before normalization.
-  /// /// DEPRCATED: Use [normalize].
+  /// DEPRECATED: Use [normalize].
   @deprecated
   double normalizeLength() => normalize();
 
@@ -178,6 +178,33 @@ class Vector2 implements Vector {
     final dy = y - arg.y;
 
     return dx * dx + dy * dy;
+  }
+
+  /// Returns the angle between [this] vector and [other] in radians.
+  double angleTo(Vector2 other) {
+    final otherStorage = other._v2storage;
+    if (_v2storage[0] == otherStorage[0] &&
+        _v2storage[1] == otherStorage[1]) {
+      return 0.0;
+    }
+
+    final d = dot(other);
+
+    return Math.acos(d.clamp(-1.0, 1.0));
+  }
+
+  /// Returns the signed angle between [this] and [other] in radians.
+  double angleToSigned(Vector2 other) {
+    final otherStorage = other._v2storage;
+    if (_v2storage[0] == otherStorage[0] &&
+        _v2storage[1] == otherStorage[1]) {
+      return 0.0;
+    }
+
+    final s = cross(other);
+    final c = dot(other);
+
+    return Math.atan2(s, c);
   }
 
   /// Inner product.

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -154,7 +154,7 @@ class Vector2 implements Vector {
   }
 
   /// Normalize [this]. Returns length of vector before normalization.
-  /// /// DEPRCATED: Use [normalize].
+  /// DEPRECATED: Use [normalize].
   @deprecated
   double normalizeLength() => normalize();
 
@@ -178,6 +178,33 @@ class Vector2 implements Vector {
     final dy = y - arg.y;
 
     return dx * dx + dy * dy;
+  }
+
+  /// Returns the angle between [this] vector and [other] in radians.
+  double angleTo(Vector2 other) {
+    final otherStorage = other._v2storage;
+    if (_v2storage[0] == otherStorage[0] &&
+        _v2storage[1] == otherStorage[1]) {
+      return 0.0;
+    }
+
+    final d = dot(other);
+
+    return Math.acos(d.clamp(-1.0, 1.0));
+  }
+
+  /// Returns the signed angle between [this] and [other] in radians.
+  double angleToSigned(Vector2 other) {
+    final otherStorage = other._v2storage;
+    if (_v2storage[0] == otherStorage[0] &&
+        _v2storage[1] == otherStorage[1]) {
+      return 0.0;
+    }
+
+    final s = cross(other);
+    final c = dot(other);
+
+    return Math.atan2(s, c);
   }
 
   /// Inner product.

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -6,6 +6,8 @@ library vector_math.test.vector2_test;
 
 import 'dart:typed_data';
 
+import 'dart:math' as Math;
+
 import 'package:test/test.dart';
 
 import 'package:vector_math/vector_math.dart';
@@ -246,6 +248,25 @@ void testVector2DistanceToSquared() {
   expect(a.distanceToSquared(c), equals(4.0));
 }
 
+void testVector2AngleTo() {
+  final v0 = new Vector2(1.0, 0.0);
+  final v1 = new Vector2(0.0, 1.0);
+
+  expect(v0.angleTo(v0), equals(0.0));
+  expect(v0.angleTo(v1), equals(Math.PI / 2.0));
+}
+
+void testVector2AngleToSigned() {
+  final v0 = new Vector2(1.0, 0.0);
+  final v1 = new Vector2(0.0, 1.0);
+  final v2 = new Vector2(-1.0, 0.0);
+
+  expect(v0.angleToSigned(v0), equals(0.0));
+  expect(v0.angleToSigned(v1), equals(Math.PI / 2.0));
+  expect(v1.angleToSigned(v0), equals(-Math.PI / 2.0));
+  expect(v0.angleToSigned(v2), equals(Math.PI));
+}
+
 void testVector2Clamp() {
   final x = 2.0, y = 3.0;
   final v0 = new Vector2(x, y);
@@ -326,6 +347,8 @@ void main() {
     test('distanceToSquared', testVector2DistanceToSquared);
     test('instancing from Float32List', testVector2InstacinfFromFloat32List);
     test('instancing from ByteBuffer', testVector2InstacingFromByteBuffer);
+    test('angleTo', testVector2AngleTo);
+    test('angleToSinged', testVector2AngleToSigned);
     test('clamp', testVector2Clamp);
     test('clampScalar', testVector2ClampScalar);
     test('floor', testVector2Floor);


### PR DESCRIPTION
This methods were already available on Vector3, but I'm missing them on Vector2.