### PR TITLE
Speedup perspective matrix, add infinite projection

### DIFF
--- a/lib/src/vector_math/opengl.dart
+++ b/lib/src/vector_math/opengl.dart
@@ -113,10 +113,16 @@ Matrix4 makeViewMatrix(
 /// (always positive).
 void setPerspectiveMatrix(Matrix4 perspectiveMatrix, double fovYRadians,
     double aspectRatio, double zNear, double zFar) {
-  double height = Math.tan(fovYRadians * 0.5) * zNear;
-  double width = height * aspectRatio;
-  setFrustumMatrix(
-      perspectiveMatrix, -width, width, -height, height, zNear, zFar);
+  final double height = Math.tan(fovYRadians * 0.5);
+  final double width = height * aspectRatio;
+  final double near_minus_far = zNear - zFar;
+
+  final Matrix4 view = perspectiveMatrix..setZero();
+  view.setEntry(0, 0, 1.0 / width);
+  view.setEntry(1, 1, 1.0 / height);
+  view.setEntry(2, 2, (zFar + zNear) / near_minus_far);
+  view.setEntry(3, 2, -1.0);
+  view.setEntry(2, 3, (2.0 * zNear * zFar) / near_minus_far);
 }
 
 /// Constructs a new OpenGL perspective projection matrix.

--- a/lib/src/vector_math/opengl.dart
+++ b/lib/src/vector_math/opengl.dart
@@ -142,6 +142,41 @@ Matrix4 makePerspectiveMatrix(
   return r;
 }
 
+/// Constructs an OpenGL infinite projection matrix in [infiniteMatrix].
+/// [fovYRadians] specifies the field of view angle, in radians, in the y
+/// direction.
+/// [aspectRatio] specifies the aspect ratio that determines the field of view
+/// in the x direction. The aspect ratio of x (width) to y (height).
+/// [zNear] specifies the distance from the viewer to the near plane
+/// (always positive).
+void setInfiniteMatrix(Matrix4 infiniteMatrix, double fovYRadians,
+    double aspectRatio, double zNear) {
+  final double height = Math.tan(fovYRadians * 0.5);
+  final double width = height * aspectRatio;
+
+  final Matrix4 view = infiniteMatrix..setZero();
+  view.setEntry(0, 0, 1.0 / width);
+  view.setEntry(1, 1, 1.0 / height);
+  view.setEntry(2, 2, -1.0);
+  view.setEntry(3, 2, -1.0);
+  view.setEntry(2, 3, -2.0 * zNear);
+}
+
+/// Constructs a new OpenGL infinite projection matrix.
+///
+/// [fovYRadians] specifies the field of view angle, in radians, in the y
+/// direction.
+/// [aspectRatio] specifies the aspect ratio that determines the field of view
+/// in the x direction. The aspect ratio of x (width) to y (height).
+/// [zNear] specifies the distance from the viewer to the near plane
+/// (always positive).
+Matrix4 makeInfiniteMatrix(
+    double fovYRadians, double aspectRatio, double zNear) {
+  Matrix4 r = new Matrix4.zero();
+  setInfiniteMatrix(r, fovYRadians, aspectRatio, zNear);
+  return r;
+}
+
 /// Constructs an OpenGL perspective projection matrix in [perspectiveMatrix].
 ///
 /// [left], [right] specify the coordinates for the left and right vertical

--- a/lib/src/vector_math_64/opengl.dart
+++ b/lib/src/vector_math_64/opengl.dart
@@ -113,10 +113,16 @@ Matrix4 makeViewMatrix(
 /// (always positive).
 void setPerspectiveMatrix(Matrix4 perspectiveMatrix, double fovYRadians,
     double aspectRatio, double zNear, double zFar) {
-  double height = Math.tan(fovYRadians * 0.5) * zNear;
-  double width = height * aspectRatio;
-  setFrustumMatrix(
-      perspectiveMatrix, -width, width, -height, height, zNear, zFar);
+  final double height = Math.tan(fovYRadians * 0.5);
+  final double width = height * aspectRatio;
+  final double near_minus_far = zNear - zFar;
+
+  final Matrix4 view = perspectiveMatrix..setZero();
+  view.setEntry(0, 0, 1.0 / width);
+  view.setEntry(1, 1, 1.0 / height);
+  view.setEntry(2, 2, (zFar + zNear) / near_minus_far);
+  view.setEntry(3, 2, -1.0);
+  view.setEntry(2, 3, (2.0 * zNear * zFar) / near_minus_far);
 }
 
 /// Constructs a new OpenGL perspective projection matrix.
@@ -133,6 +139,41 @@ Matrix4 makePerspectiveMatrix(
     double fovYRadians, double aspectRatio, double zNear, double zFar) {
   Matrix4 r = new Matrix4.zero();
   setPerspectiveMatrix(r, fovYRadians, aspectRatio, zNear, zFar);
+  return r;
+}
+
+/// Constructs an OpenGL infinite projection matrix in [infiniteMatrix].
+/// [fovYRadians] specifies the field of view angle, in radians, in the y
+/// direction.
+/// [aspectRatio] specifies the aspect ratio that determines the field of view
+/// in the x direction. The aspect ratio of x (width) to y (height).
+/// [zNear] specifies the distance from the viewer to the near plane
+/// (always positive).
+void setInfiniteMatrix(Matrix4 infiniteMatrix, double fovYRadians,
+    double aspectRatio, double zNear) {
+  final double height = Math.tan(fovYRadians * 0.5);
+  final double width = height * aspectRatio;
+
+  final Matrix4 view = infiniteMatrix..setZero();
+  view.setEntry(0, 0, 1.0 / width);
+  view.setEntry(1, 1, 1.0 / height);
+  view.setEntry(2, 2, -1.0);
+  view.setEntry(3, 2, -1.0);
+  view.setEntry(2, 3, -2.0 * zNear);
+}
+
+/// Constructs a new OpenGL infinite projection matrix.
+///
+/// [fovYRadians] specifies the field of view angle, in radians, in the y
+/// direction.
+/// [aspectRatio] specifies the aspect ratio that determines the field of view
+/// in the x direction. The aspect ratio of x (width) to y (height).
+/// [zNear] specifies the distance from the viewer to the near plane
+/// (always positive).
+Matrix4 makeInfiniteMatrix(
+    double fovYRadians, double aspectRatio, double zNear) {
+  Matrix4 r = new Matrix4.zero();
+  setInfiniteMatrix(r, fovYRadians, aspectRatio, zNear);
   return r;
 }
 

--- a/test/opengl_matrix_test.dart
+++ b/test/opengl_matrix_test.dart
@@ -4,6 +4,7 @@
 
 library vector_math.test.opengl_matrix_test;
 
+import 'dart:math';
 import 'package:test/test.dart';
 
 import 'package:vector_math/vector_math.dart';
@@ -63,6 +64,21 @@ void testFrustumMatrix() {
       frustum.getColumn(3), new Vector4(0.0, 0.0, -2.0 * f * n / (f - n), 0.0));
 }
 
+void testPerspectiveMatrix() {
+  final double fov = PI / 2;
+  final double aspectRatio = 2.0;
+  final double zNear = 1.0;
+  final double zFar = 100.0;
+
+  Matrix4 perspective = makePerspectiveMatrix(fov, aspectRatio, zNear, zFar);
+  relativeTest(perspective.getColumn(0), new Vector4(0.5, 0.0, 0.0, 0.0));
+  relativeTest(perspective.getColumn(1), new Vector4(0.0, 1.0, 0.0, 0.0));
+  relativeTest(
+      perspective.getColumn(2), new Vector4(0.0, 0.0, -101.0 / 99.0, -1.0));
+  relativeTest(
+      perspective.getColumn(3), new Vector4(0.0, 0.0, -200.0 / 99.0, 0.0));
+}
+
 void testOrthographicMatrix() {
   num n = 0.1;
   num f = 1000.0;
@@ -110,6 +126,7 @@ void main() {
     test('LookAt', testLookAt);
     test('Unproject', testUnproject);
     test('Frustum', testFrustumMatrix);
+    test('Perspective', testPerspectiveMatrix);
     test('Orthographic', testOrthographicMatrix);
     test('ModelMatrix', testModelMatrix);
   });

--- a/test/opengl_matrix_test.dart
+++ b/test/opengl_matrix_test.dart
@@ -79,6 +79,18 @@ void testPerspectiveMatrix() {
       perspective.getColumn(3), new Vector4(0.0, 0.0, -200.0 / 99.0, 0.0));
 }
 
+void testInfiniteMatrix() {
+  final double fov = PI / 2;
+  final double aspectRatio = 2.0;
+  final double zNear = 1.0;
+
+  Matrix4 infinite = makeInfiniteMatrix(fov, aspectRatio, zNear);
+  relativeTest(infinite.getColumn(0), new Vector4(0.5, 0.0, 0.0, 0.0));
+  relativeTest(infinite.getColumn(1), new Vector4(0.0, 1.0, 0.0, 0.0));
+  relativeTest(infinite.getColumn(2), new Vector4(0.0, 0.0, -1.0, -1.0));
+  relativeTest(infinite.getColumn(3), new Vector4(0.0, 0.0, -2.0, 0.0));
+}
+
 void testOrthographicMatrix() {
   num n = 0.1;
   num f = 1000.0;
@@ -127,6 +139,7 @@ void main() {
     test('Unproject', testUnproject);
     test('Frustum', testFrustumMatrix);
     test('Perspective', testPerspectiveMatrix);
+    test('Infinite', testInfiniteMatrix);
     test('Orthographic', testOrthographicMatrix);
     test('ModelMatrix', testModelMatrix);
   });


### PR DESCRIPTION
This PR:
1. Speeds up `setPerspectiveMatrix` by inlining simplified version of `setFrustumMatrix` (less operations, less function calls). It gives ~11% speed boost in dart2js compiled version.
2. Adds support for infinite projection matrices.
   
   > Tightening the Precision of Perspective Rendering
   > Paul Upchurch, Mathieu Desbrun
   > Journal of Graphics Tools, Volume 16, Issue 1, 2012
