### PR TITLE
Add Matrix4.tryToInvert static method to support trying to invert a matrix without throwing an exception.

### DIFF
--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -148,6 +148,17 @@ class Matrix4 {
               (a20 * b03 - a21 * b01 + a22 * b00) * bW);
   }
 
+  /// Returns a matrix that is the inverse of [other] if [other] is invertible,
+  /// otherwise `null`.
+  static Matrix4 tryInvert(Matrix4 other) {
+    final Matrix4 r = new Matrix4.zero();
+    final double determinant = r.copyInverse(other);
+    if (determinant == 0.0) {
+      return null;
+    }
+    return r;
+  }
+
   /// Return index in storage for [row], [col] value.
   int index(int row, int col) => (col * 4) + row;
 

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -613,6 +613,12 @@ void testMatrix4InvertConstructor() {
       equals(new Matrix4.identity()));
 }
 
+void testMatrix4tryInvert() {
+  expect(Matrix4.tryInvert(new Matrix4.zero()), isNull);
+  expect(Matrix4.tryInvert(new Matrix4.identity()),
+      equals(new Matrix4.identity()));
+}
+
 void testMatrix4SkewConstructor() {
   var m = new Matrix4.skew(0.0, 1.57);
   var m2 = new Matrix4.skewY(1.57);
@@ -701,6 +707,7 @@ void main() {
     test('compose/decompose', testMatrix4Compose);
     test('equals', testMatrix4Equals);
     test('invert constructor', testMatrix4InvertConstructor);
+    test('tryInvert', testMatrix4tryInvert);
     test('skew constructor', testMatrix4SkewConstructor);
     test('leftTranslate', testLeftTranslate);
     test('matrix classifiers', testMatrixClassifiers);


### PR DESCRIPTION
I'm open to alternate method names and to making this an instance method instead of a static method.
I've made this a static method as that appears more consistent with the existing API where instance methods modify the matrix instead of returning a new matrix.

Having this method will be nice for flutter as there are cases hit testing where it is fine for a matrix to be non-invertible. Throwing an exception means running a flutter app with a transform matrix like `scale(0.0) ` with "pause on caught exceptions" will pause frequently.