### PR TITLE
Fixed indexing bug in MeshGeometry.combine

### DIFF
--- a/lib/src/vector_math_geometry/mesh_geometry.dart
+++ b/lib/src/vector_math_geometry/mesh_geometry.dart
@@ -213,14 +213,16 @@ class MeshGeometry {
     // Copy over the buffer data:
     int bufferOffset = 0;
     int indexOffset = 0;
+    int vertexOffset = 0;
     for (int i = 0; i < meshes.length; ++i) {
       final MeshGeometry srcMesh = meshes[i];
       mesh.buffer.setAll(bufferOffset, srcMesh.buffer);
 
       if (totalIndices > 0) {
         for (int j = 0; j < srcMesh.indices.length; ++j) {
-          mesh.indices[j + indexOffset] = srcMesh.indices[j] + bufferOffset;
+          mesh.indices[j + indexOffset] = srcMesh.indices[j] + vertexOffset;
         }
+        vertexOffset += srcMesh.length;
         indexOffset += srcMesh.indices.length;
       }
 

--- a/test/geometry_test.dart
+++ b/test/geometry_test.dart
@@ -122,11 +122,25 @@ void testColorFilter() {
   }
 }
 
+void testCombineIndices() {
+  // Combining two meshes should generate indices that are not out of range.
+  SphereGenerator sphereGenerator = new SphereGenerator();
+
+  MeshGeometry sphere0 = sphereGenerator.createSphere(10.0,
+      latSegments: 8, lonSegments: 8);
+  MeshGeometry sphere1 = sphereGenerator.createSphere(10.0,
+      latSegments: 8, lonSegments: 8);
+
+  MeshGeometry combined = new MeshGeometry.combine([sphere0, sphere1]);
+  expect(combined.indices, everyElement(lessThan(combined.length)));  
+}
+
 void main() {
   group('Geometry', () {
     group('Generators', () {
       test('normal generation', testGenerateNormals);
       test('tangent generation', testGenerateTangents);
+      test('geometry combination', testCombineIndices);
     });
     group('Filters', () {
       test('transform filter', testTransformFilter);


### PR DESCRIPTION
Bug fix in MeshGeometry.combine that corrects indexing (previous was incrementing index offset by the size of the vertex buffer, new increments by number of vertices).