### PR TITLE
Reuse Matrix3, Matrix4 and Vector3 in decompose

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## 2.0.9
 
 - Update Dart SDK constraint to `>=2.1.0 <3.0.0`.
+- Improve performance of Matrix4.decompose by reusing objects.
 
 ## v 2.0.8 - July 2018
 

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1794,7 +1794,8 @@ class Matrix4 {
     final double invSY = 1.0 / sy;
     final double invSZ = 1.0 / sz;
 
-    final Matrix4 m = Matrix4.copy(this);
+    final Matrix4 m = _decomposeM ??= Matrix4.zero();
+    m.setFrom(this);
     m._m4storage[0] *= invSX;
     m._m4storage[1] *= invSX;
     m._m4storage[2] *= invSX;
@@ -1805,12 +1806,17 @@ class Matrix4 {
     m._m4storage[9] *= invSZ;
     m._m4storage[10] *= invSZ;
 
-    rotation.setFromRotation(m.getRotation());
+    final Matrix3 r = _decomposeR ??= Matrix3.zero();
+    m.copyRotation(r);
+    rotation.setFromRotation(r);
 
     scale._v3storage[0] = sx;
     scale._v3storage[1] = sy;
     scale._v3storage[2] = sz;
   }
+
+  static Matrix4 _decomposeM;
+  static Matrix3 _decomposeR;
 
   /// Rotate [arg] of type [Vector3] using the rotation defined by this.
   Vector3 rotate3(Vector3 arg) {

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1774,7 +1774,7 @@ class Matrix4 {
 
   /// Decomposes this into [translation], [rotation] and [scale] components.
   void decompose(Vector3 translation, Quaternion rotation, Vector3 scale) {
-    final Vector3 v = Vector3.zero();
+    final Vector3 v = _decomposeV ??= Vector3.zero();
     double sx =
         (v..setValues(_m4storage[0], _m4storage[1], _m4storage[2])).length;
     final double sy =
@@ -1815,6 +1815,7 @@ class Matrix4 {
     scale._v3storage[2] = sz;
   }
 
+  static Vector3 _decomposeV;
   static Matrix4 _decomposeM;
   static Matrix3 _decomposeR;
 

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -1794,7 +1794,8 @@ class Matrix4 {
     final double invSY = 1.0 / sy;
     final double invSZ = 1.0 / sz;
 
-    final Matrix4 m = Matrix4.copy(this);
+    final Matrix4 m = _decomposeM ??= Matrix4.zero();
+    m.setFrom(this);
     m._m4storage[0] *= invSX;
     m._m4storage[1] *= invSX;
     m._m4storage[2] *= invSX;
@@ -1805,12 +1806,17 @@ class Matrix4 {
     m._m4storage[9] *= invSZ;
     m._m4storage[10] *= invSZ;
 
-    rotation.setFromRotation(m.getRotation());
+    final Matrix3 r = _decomposeR ??= Matrix3.zero();
+    m.copyRotation(r);
+    rotation.setFromRotation(r);
 
     scale._v3storage[0] = sx;
     scale._v3storage[1] = sy;
     scale._v3storage[2] = sz;
   }
+
+  static Matrix4 _decomposeM;
+  static Matrix3 _decomposeR;
 
   /// Rotate [arg] of type [Vector3] using the rotation defined by this.
   Vector3 rotate3(Vector3 arg) {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -1774,7 +1774,7 @@ class Matrix4 {
 
   /// Decomposes this into [translation], [rotation] and [scale] components.
   void decompose(Vector3 translation, Quaternion rotation, Vector3 scale) {
-    final Vector3 v = Vector3.zero();
+    final Vector3 v = _decomposeV ??= Vector3.zero();
     double sx =
         (v..setValues(_m4storage[0], _m4storage[1], _m4storage[2])).length;
     final double sy =
@@ -1815,6 +1815,7 @@ class Matrix4 {
     scale._v3storage[2] = sz;
   }
 
+  static Vector3 _decomposeV;
   static Matrix4 _decomposeM;
   static Matrix3 _decomposeR;
 


### PR DESCRIPTION
The reduction in allocations improves the performance of the Matrix4Tween benchmarks by roughly 20%

JIT VM
Matrix4TweenBenchmark1(RunTime): 6488.954692556635 us.
Matrix4TweenBenchmark2(RunTime): 4512.9009009009005 us.
Matrix4TweenBenchmark3(RunTime): 4744.867298578199 us.
--->
Matrix4TweenBenchmark1(RunTime): 5072.906329113924 us.
Matrix4TweenBenchmark2(RunTime): 3204.7952 us.
Matrix4TweenBenchmark3(RunTime): 3394.628813559322 us.

JSC:
Matrix4TweenBenchmark1(RunTime): 12300.613496932516 us.
Matrix4TweenBenchmark2(RunTime): 9578.947368421053 us.
Matrix4TweenBenchmark3(RunTime): 7347.985347985348 us.
--->
Matrix4TweenBenchmark1(RunTime): 10287.179487179486 us.
Matrix4TweenBenchmark2(RunTime): 7948.412698412699 us.
Matrix4TweenBenchmark3(RunTime): 5717.142857142857 us.

Chrome 74:
Chrome has a serious performance problem with allocating Float64Array(9) and Float64Array(16).
This makes the Chrome impact of the allocation reductions much higher. This is V8 issue 9199
Matrix4TweenBenchmark1(RunTime): 66481.45161290323 us.
Matrix4TweenBenchmark2(RunTime): 63572.8125 us.
Matrix4TweenBenchmark3(RunTime): 60984.666666666664 us.
--->
Matrix4TweenBenchmark1(RunTime): 30604.090909090908 us.
Matrix4TweenBenchmark2(RunTime): 26960.68 us.
Matrix4TweenBenchmark3(RunTime): 19803.663366336634 us.