### PR TITLE
Fixed error when Matrix4 translate and scale x argument is given an i…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## 2.1.0
+
+- Removed dynamic dispatch for translate, leftTranslate, scale and scaled methods in Matrix4
+- All methods above now use doubles by default. Add 'byVector3' and 'byVector4' to any function for using respective function. (E.g: translate -> translateByVector3)
+
 ## 2.0.9
 
 - Update Dart SDK constraint to `>=2.3.0 <3.0.0`.

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -461,7 +461,7 @@ class Matrix4 {
   void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
-    this.scale(scale);
+    scaleByVector3(scale);
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
@@ -660,25 +660,22 @@ class Matrix4 {
   /// Returns new matrix after component wise this - [arg]
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
-  /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
-  void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final double tw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
-    }
+  /// Translate using [x],[y],[z] values
+  void translate(double x, [double y = 0.0, double z = 0.0]) {
+    _translate(x, y, z, 1.0);
+  }
+
+  /// Translate using [Vector3]
+  void translateByVector3(Vector3 v)  {
+    _translate(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Translate using [Vector4]
+  void translateByVector4(Vector4 v) {
+    _translate(v.x, v.y, v.z, v.w);
+  }
+
+  void _translate(double tx, double ty, double tz, double tw) {
     final double t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
@@ -701,27 +698,22 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
-  /// Multiply this by a translation from the left.
-  /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.
-  void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final double tw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
-    }
+  /// Multiply this by a translation from the left using [x],[y],[z].
+  void leftTranslate(double x, [double y = 0.0, double z = 0.0]) {
+    _leftTranslate(x, y, z, 1.0);
+  }
 
+  /// Multiply this by a translation from the left using [Vector3].
+  void leftTranslateByVector3(Vector3 v)  {
+    _leftTranslate(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Multiply this by a translation from the left using [Vector4].
+  void leftTranslateByVector4(Vector4 v) {
+    _leftTranslate(v.x, v.y, v.z, v.w);
+  }
+
+  void _leftTranslate(double tx, double ty, double tz, double tw) {
     // Column 1
     _m4storage[0] += tx * _m4storage[3];
     _m4storage[1] += ty * _m4storage[3];
@@ -870,25 +862,22 @@ class Matrix4 {
     _m4storage[7] = t8;
   }
 
-  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
-  void scale(dynamic x, [double y, double z]) {
-    double sx;
-    double sy;
-    double sz;
-    final double sw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
-    } else if (x is Vector4) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
-    } else if (x is double) {
-      sx = x;
-      sy = y ?? x;
-      sz = z ?? x;
-    }
+  /// Scale this matrix by [x],[y],[z]
+  void scale(double x, [double y = 0.0, double z = 0.0]) {
+    _scale(x, y, z, 1.0);
+  }
+
+  /// Scale this matrix by a [Vector3]
+  void scaleByVector3(Vector3 v) {
+    _scale(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Scale this matrix by a [Vector4]
+  void scaleByVector4(Vector4 v) {
+    _scale(v.x, v.y, v.z, v.w);
+  }
+
+  void _scale(double sx, double sy, double sz, double sw) {
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -907,9 +896,14 @@ class Matrix4 {
     _m4storage[15] *= sw;
   }
 
-  /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
-  /// [z].
-  Matrix4 scaled(dynamic x, [double y, double z]) => clone()..scale(x, y, z);
+  /// Create a copy of this scaled by [x],[y],[z]
+  Matrix4 scaled(double x, [double y, double z]) => clone()..scale(x, y, z);
+
+  /// Create a copy of this scaled by a [Vector3]
+  Matrix4 scaledByVector3(Vector3 x) => clone()..scaleByVector3(x);
+
+  /// Create a copy of this scaled by a [Vector4]
+  Matrix4 scaledByVector4(Vector4 x) => clone()..scaleByVector4(x);
 
   /// Zeros this.
   void setZero() {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -461,7 +461,7 @@ class Matrix4 {
   void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
-    this.scale(scale.x, scale.y, scale.z);
+    scaleByVector3(scale);
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
@@ -660,15 +660,22 @@ class Matrix4 {
   /// Returns new matrix after component wise this - [arg]
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
-  /// Translate this matrix by doubles x,y,z
+  /// Translate using [x],[y],[z] values
   void translate(double x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final double tw = 1.0;
-    tx = x;
-    ty = y;
-    tz = z;
+    _translate(x, y, z, 1.0);
+  }
+
+  /// Translate using [Vector3]
+  void translateByVector3(Vector3 v)  {
+    _translate(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Translate using [Vector4]
+  void translateByVector4(Vector4 v) {
+    _translate(v.x, v.y, v.z, v.w);
+  }
+
+  void _translate(double tx, double ty, double tz, double tw) {
     final double t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
@@ -691,17 +698,22 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
-  /// Multiply this by a translation from the left.
-  /// The translation can be specified with x, y, z.
+  /// Multiply this by a translation from the left using [x],[y],[z].
   void leftTranslate(double x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final double tw = 1.0;
-    tx = x;
-    ty = y;
-    tz = z;
+    _leftTranslate(x, y, z, 1.0);
+  }
 
+  /// Multiply this by a translation from the left using [Vector3].
+  void leftTranslateByVector3(Vector3 v)  {
+    _leftTranslate(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Multiply this by a translation from the left using [Vector4].
+  void leftTranslateByVector4(Vector4 v) {
+    _leftTranslate(v.x, v.y, v.z, v.w);
+  }
+
+  void _leftTranslate(double tx, double ty, double tz, double tw) {
     // Column 1
     _m4storage[0] += tx * _m4storage[3];
     _m4storage[1] += ty * _m4storage[3];
@@ -850,15 +862,22 @@ class Matrix4 {
     _m4storage[7] = t8;
   }
 
-  /// Scale this matrix by x,y,z
-  void scale(double x, [double y, double z]) {
-    double sx;
-    double sy;
-    double sz;
-    final double sw = 1.0;
-    sx = x;
-    sy = y ?? x;
-    sz = z ?? x;
+  /// Scale this matrix by [x],[y],[z]
+  void scale(double x, [double y = 0.0, double z = 0.0]) {
+    _scale(x, y, z, 1.0);
+  }
+
+  /// Scale this matrix by a [Vector3]
+  void scaleByVector3(Vector3 v) {
+    _scale(v.x, v.y, v.z, 1.0);
+  }
+
+  /// Scale this matrix by a [Vector4]
+  void scaleByVector4(Vector4 v) {
+    _scale(v.x, v.y, v.z, v.w);
+  }
+
+  void _scale(double sx, double sy, double sz, double sw) {
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -877,8 +896,14 @@ class Matrix4 {
     _m4storage[15] *= sw;
   }
 
-  /// Create a copy of this scaled by [x],[y], and [z].
+  /// Create a copy of this scaled by [x],[y],[z]
   Matrix4 scaled(double x, [double y, double z]) => clone()..scale(x, y, z);
+
+  /// Create a copy of this scaled by a [Vector3]
+  Matrix4 scaledByVector3(Vector3 x) => clone()..scaleByVector3(x);
+
+  /// Create a copy of this scaled by a [Vector4]
+  Matrix4 scaledByVector4(Vector4 x) => clone()..scaleByVector4(x);
 
   /// Zeros this.
   void setZero() {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -678,6 +678,10 @@ class Matrix4 {
       tx = x;
       ty = y;
       tz = z;
+    } else if (x is int) {
+      tx = x.toDouble();
+      ty = y;
+      tz = z;
     }
     final double t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
@@ -718,6 +722,10 @@ class Matrix4 {
       tz = x.z;
     } else if (x is double) {
       tx = x;
+      ty = y;
+      tz = z;
+    } else if (x is int) {
+      tx = x.toDouble();
       ty = y;
       tz = z;
     }
@@ -888,6 +896,10 @@ class Matrix4 {
       sx = x;
       sy = y ?? x;
       sz = z ?? x;
+    } else if (x is int) {
+      sx = x.toDouble();
+      sy = y ?? x.toDouble();
+      sz = z ?? x.toDouble();
     }
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -461,7 +461,7 @@ class Matrix4 {
   void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
-    this.scale(scale);
+    this.scale(scale.x, scale.y, scale.z);
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
@@ -660,29 +660,15 @@ class Matrix4 {
   /// Returns new matrix after component wise this - [arg]
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
-  /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
-  void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
+  /// Translate this matrix by doubles x,y,z
+  void translate(double x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
     double tz;
-    final double tw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
-    } else if (x is int) {
-      tx = x.toDouble();
-      ty = y;
-      tz = z;
-    }
+    final double tw = 1.0;
+    tx = x;
+    ty = y;
+    tz = z;
     final double t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
@@ -706,29 +692,15 @@ class Matrix4 {
   }
 
   /// Multiply this by a translation from the left.
-  /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.
-  void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
+  /// The translation can be specified with x, y, z.
+  void leftTranslate(double x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
     double tz;
-    final double tw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
-    } else if (x is int) {
-      tx = x.toDouble();
-      ty = y;
-      tz = z;
-    }
+    final double tw = 1.0;
+    tx = x;
+    ty = y;
+    tz = z;
 
     // Column 1
     _m4storage[0] += tx * _m4storage[3];
@@ -878,29 +850,15 @@ class Matrix4 {
     _m4storage[7] = t8;
   }
 
-  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
-  void scale(dynamic x, [double y, double z]) {
+  /// Scale this matrix by x,y,z
+  void scale(double x, [double y, double z]) {
     double sx;
     double sy;
     double sz;
-    final double sw = x is Vector4 ? x.w : 1.0;
-    if (x is Vector3) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
-    } else if (x is Vector4) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
-    } else if (x is double) {
-      sx = x;
-      sy = y ?? x;
-      sz = z ?? x;
-    } else if (x is int) {
-      sx = x.toDouble();
-      sy = y ?? x.toDouble();
-      sz = z ?? x.toDouble();
-    }
+    final double sw = 1.0;
+    sx = x;
+    sy = y ?? x;
+    sz = z ?? x;
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -919,9 +877,8 @@ class Matrix4 {
     _m4storage[15] *= sw;
   }
 
-  /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
-  /// [z].
-  Matrix4 scaled(dynamic x, [double y, double z]) => clone()..scale(x, y, z);
+  /// Create a copy of this scaled by [x],[y], and [z].
+  Matrix4 scaled(double x, [double y, double z]) => clone()..scale(x, y, z);
 
   /// Zeros this.
   void setZero() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.0.9-dev
+version: 2.1.0-dev
 author: John McCutchan <john@johnmccutchan.com>
 description: A Vector Math library for 2D and 3D applications.
 homepage: https://github.com/google/vector_math.dart

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -376,6 +376,44 @@ void testMatrix4Translation() {
   }
 }
 
+void testMatrix4TranslationByVector3() {
+  final inputA = <Matrix4>[];
+  final inputB = <Matrix4>[];
+  final output1 = <Matrix4>[];
+  final output2 = <Matrix4>[];
+
+  inputA.add(Matrix4.identity());
+  inputB.add(Matrix4.translationValues(1.0, 3.0, 5.7));
+  output1.add(inputA[0] * inputB[0] as Matrix4);
+  output2.add((Matrix4.identity())..translateByVector3(Vector3(1.0, 3.0, 5.7)));
+
+  assert(inputA.length == inputB.length);
+  assert(output1.length == output2.length);
+
+  for (var i = 0; i < inputA.length; i++) {
+    relativeTest(output1[i], output2[i]);
+  }
+}
+
+void testMatrix4TranslationByVector4() {
+  final inputA = <Matrix4>[];
+  final inputB = <Matrix4>[];
+  final output1 = <Matrix4>[];
+  final output2 = <Matrix4>[];
+
+  inputA.add(Matrix4.identity());
+  inputB.add(Matrix4.translationValues(1.0, 3.0, 5.7));
+  output1.add(inputA[0] * inputB[0] as Matrix4);
+  output2.add((Matrix4.identity())..translateByVector4(Vector4(1.0, 3.0, 5.7, 1.0)));
+
+  assert(inputA.length == inputB.length);
+  assert(output1.length == output2.length);
+
+  for (var i = 0; i < inputA.length; i++) {
+    relativeTest(output1[i], output2[i]);
+  }
+}
+
 void testMatrix4Scale() {
   final inputA = <Matrix4>[];
   final inputB = <Matrix4>[];
@@ -386,6 +424,44 @@ void testMatrix4Scale() {
   inputB.add(Matrix4.diagonal3Values(1.0, 3.0, 5.7));
   output1.add(inputA[0] * inputB[0] as Matrix4);
   output2.add(Matrix4.identity()..scale(1.0, 3.0, 5.7));
+
+  assert(inputA.length == inputB.length);
+  assert(output1.length == output2.length);
+
+  for (var i = 0; i < inputA.length; i++) {
+    relativeTest(output1[i], output2[i]);
+  }
+}
+
+void testMatrix4ScaleByVector3() {
+  final inputA = <Matrix4>[];
+  final inputB = <Matrix4>[];
+  final output1 = <Matrix4>[];
+  final output2 = <Matrix4>[];
+
+  inputA.add(Matrix4.identity());
+  inputB.add(Matrix4.diagonal3Values(1.0, 3.0, 5.7));
+  output1.add(inputA[0] * inputB[0] as Matrix4);
+  output2.add(Matrix4.identity()..scaleByVector3(Vector3(1.0, 3.0, 5.7)));
+
+  assert(inputA.length == inputB.length);
+  assert(output1.length == output2.length);
+
+  for (var i = 0; i < inputA.length; i++) {
+    relativeTest(output1[i], output2[i]);
+  }
+}
+
+void testMatrix4ScaleByVector4() {
+  final inputA = <Matrix4>[];
+  final inputB = <Matrix4>[];
+  final output1 = <Matrix4>[];
+  final output2 = <Matrix4>[];
+
+  inputA.add(Matrix4.identity());
+  inputB.add(Matrix4.diagonal3Values(1.0, 3.0, 5.7));
+  output1.add(inputA[0] * inputB[0] as Matrix4);
+  output2.add(Matrix4.identity()..scaleByVector4(Vector4(1.0, 3.0, 5.7, 1.0)));
 
   assert(inputA.length == inputB.length);
   assert(output1.length == output2.length);
@@ -662,6 +738,68 @@ void testLeftTranslate() {
   expect(result.z, equals(0.0));
 }
 
+void testLeftTranslateByVector3() {
+  // Our test point.
+  final p = Vector3(0.5, 0.0, 0.0);
+
+  // Scale 2x matrix.
+  var m = Matrix4.diagonal3Values(2.0, 2.0, 2.0);
+  // After scaling, translate along the X axis.
+  m.leftTranslateByVector3(Vector3(1.0, 0.0, 0.0));
+
+  // Apply the transformation to p. This will move (0.5, 0, 0) to (2.0, 0, 0).
+  // Scale: 0.5 -> 1.0.
+  // Translate: 1.0 -> 2.0
+  var result = m.transformed3(p);
+  expect(result.x, equals(2.0));
+  expect(result.y, equals(0.0));
+  expect(result.z, equals(0.0));
+
+  // Scale 2x matrix.
+  m = Matrix4.diagonal3Values(2.0, 2.0, 2.0);
+  // Before scaling, translate along the X axis.
+  m.translate(1.0);
+
+  // Apply the transformation to p. This will move (0.5, 0, 0) to (3.0, 0, 0).
+  // Translate: 0.5 -> 1.5.
+  // Scale: 1.5 -> 3.0.
+  result = m.transformed3(p);
+  expect(result.x, equals(3.0));
+  expect(result.y, equals(0.0));
+  expect(result.z, equals(0.0));
+}
+
+void testLeftTranslateByVector4() {
+  // Our test point.
+  final p = Vector3(0.5, 0.0, 0.0);
+
+  // Scale 2x matrix.
+  var m = Matrix4.diagonal3Values(2.0, 2.0, 2.0);
+  // After scaling, translate along the X axis.
+  m.leftTranslateByVector4(Vector4(1.0, 0.0, 0.0, 0.0));
+
+  // Apply the transformation to p. This will move (0.5, 0, 0) to (2.0, 0, 0).
+  // Scale: 0.5 -> 1.0.
+  // Translate: 1.0 -> 2.0
+  var result = m.transformed3(p);
+  expect(result.x, equals(2.0));
+  expect(result.y, equals(0.0));
+  expect(result.z, equals(0.0));
+
+  // Scale 2x matrix.
+  m = Matrix4.diagonal3Values(2.0, 2.0, 2.0);
+  // Before scaling, translate along the X axis.
+  m.translate(1.0);
+
+  // Apply the transformation to p. This will move (0.5, 0, 0) to (3.0, 0, 0).
+  // Translate: 0.5 -> 1.5.
+  // Scale: 1.5 -> 3.0.
+  result = m.transformed3(p);
+  expect(result.x, equals(3.0));
+  expect(result.y, equals(0.0));
+  expect(result.z, equals(0.0));
+}
+
 void testMatrixClassifiers() {
   expect(Matrix4.zero().isIdentity(), false);
   expect(Matrix4.zero().isZero(), true);
@@ -682,7 +820,11 @@ void main() {
     test('Matrix multiplication', testMatrix4Multiplication);
     test('Matrix vector multiplication', testMatrix4VectorMultiplication);
     test('Matrix translate', testMatrix4Translation);
+    test('Matrix translate by Vector3', testMatrix4TranslationByVector3);
+    test('Matrix translate by Vector4', testMatrix4TranslationByVector4);
     test('Scale matrix', testMatrix4Scale);
+    test('Scale matrix by Vector3', testMatrix4ScaleByVector3);
+    test('Scale matrix by Vector4', testMatrix4ScaleByVector4);
     test('Rotate matrix', testMatrix4Rotate);
     test('Get rotation matrix', testMatrix4GetRotation);
     test('Set column', testMatrix4Column);
@@ -696,6 +838,8 @@ void main() {
     test('tryInvert', testMatrix4tryInvert);
     test('skew constructor', testMatrix4SkewConstructor);
     test('leftTranslate', testLeftTranslate);
+    test('leftTranslate Vector3', testLeftTranslateByVector3);
+    test('leftTranslate Vector4', testLeftTranslateByVector4);
     test('matrix classifiers', testMatrixClassifiers);
   });
 }


### PR DESCRIPTION
The `translate`, `leftTranslate` and `scale` methods of the Matrix4 class give errors when the x parameter is given an integer since x is dynamic while y and z are explicit doubles. 

This makes the function call `.translate(0.0, 0, 0)` possible but `.translate(0,0,0)` not possible as:
`if (x is double)` does not capture the integer x but the y and z values are already implicitly converted to doubles. The possible solutions are:

1) (Implemented here) Add a fourth else if to check if x is integer and convert x to double before assigning to tx.
2) Converting the last else if condition to else, removing the double check. This would give more room for other conditions where the object has a toDouble() method, so this method was avoided.

This fix makes calls like .translate(0,0,0) possible.