### PR TITLE
update for the 2.10 dev sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: dart
 
 dart:
-  - dev
+  - preview/raw/2.10.0-0.2-dev
 
 script: ./tool/travis.sh
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master, null_safety]
+  only: [master]
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v 2.1.0-nullsafety.2
+
+* Update for the 2.10 dev sdk.
+
 ## v 2.1.0-nullsafety.1
 
 * Allow the <=2.9.10 stable sdks.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: vector_math
-version: 2.1.0-nullsafety.1
+version: 2.1.0-nullsafety.2
 description: A Vector Math library for 2D and 3D applications.
 homepage: https://github.com/google/vector_math.dart
 
 environment:
-  # This must remain a tight constraint (only allow dev versions) until nnbd is
-  # stable.
-  sdk: '>=2.9.0-18.0 <=2.9.10'
+  # This must remain a tight constraint until nnbd is stable
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dev_dependencies:
   benchmark_harness: any
@@ -31,12 +30,14 @@ dependency_overrides:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/js
+      ref: 2-10-pkgs
   matcher:
     git: git://github.com/dart-lang/matcher.git
   meta:
     git:
       url: git://github.com/dart-lang/sdk.git
       path: pkg/meta
+      ref: 2-10-pkgs
   path:
     git: git://github.com/dart-lang/path.git
   pedantic:


### PR DESCRIPTION
This is in preparation for the actual 2.10 dev sdk release. This package needs to be published and pinned in flutter simultaneously with that release.

The tests are going to be failing until we update all transitive deps in a similar fashion (they need to declare a 2.10 language version).

The plan for lack of a better option is to just do these all as quickly as possible (and merge them into master), and then go re-run the travis jobs to get the build green again afterwords.