### PR TITLE
use object hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.12.0, dev]
+        sdk: [2.14.0, dev]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.0
+      - uses: actions/checkout@v2.3.4
+      - uses: dart-lang/setup-dart@v1.2
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.1.1-dev
+## 2.1.1
+
+- Deprecate `hash.dart`.
+- Require Dart v2.14 or greater.
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,31 +3,6 @@
 ## 2.1.0
 
 - Stable release for null safety.
-
-## 2.1.0-nullsafety.5
-
-- Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
-  guidelines.
-
-## 2.1.0-nullsafety.4
-
-- Allow prerelease versions of the 2.12 sdk.
-
-## 2.1.0-nullsafety.3
-
-- Allow 2.10 stable and 2.11.0 dev SDK versions.
-
-## 2.1.0-nullsafety.2
-
-- Update for the 2.10 dev sdk.
-
-## 2.1.0-nullsafety.1
-
-- Allow the <=2.9.10 stable sdks.
-
-## 2.1.0-nullsafety
-
-- Migrate to null safety
 - Improve performance of Matrix4.decompose by reusing objects.
 
 ## 2.0.8 - July 2018

--- a/lib/hash.dart
+++ b/lib/hash.dart
@@ -1,22 +1,12 @@
-// Copyrigha (c) 2016, Google Inc. Please see the AUTHORS file for details.
+// Copyright (c) 2016, Google Inc. Please see the AUTHORS file for details.
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+@Deprecated('Use Object.hashAll instead')
+library hash;
 
 ///
 /// Generates a hash code for multiple [objects].
 ///
-int hashObjects(Iterable<Object> objects) =>
-    _finish(objects.fold<int>(0, (int h, Object i) => _combine(h, i.hashCode)));
-
-// Jenkins hash functions
-int _combine(int hash, int value) {
-  hash = 0x1fffffff & (hash + value);
-  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-  return hash ^ (hash >> 6);
-}
-
-int _finish(int hash) {
-  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-  hash = hash ^ (hash >> 11);
-  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-}
+@Deprecated('Use Object.hashAll instead')
+int hashObjects(Iterable<Object> objects) => Object.hashAll(objects);

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -153,7 +153,7 @@ class Matrix2 {
       (_m2storage[3] == other._m2storage[3]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m2storage);
+  int get hashCode => Object.hashAll(_m2storage);
 
   /// Returns row 0
   Vector2 get row0 => getRow(0);

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -249,7 +249,7 @@ class Matrix3 {
       (_m3storage[8] == other._m3storage[8]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m3storage);
+  int get hashCode => Object.hashAll(_m3storage);
 
   /// Returns row 0
   Vector3 get row0 => getRow(0);

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -541,7 +541,7 @@ class Matrix4 {
       (_m4storage[15] == other._m4storage[15]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m4storage);
+  int get hashCode => Object.hashAll(_m4storage);
 
   /// Returns row 0
   Vector4 get row0 => getRow(0);

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -102,7 +102,7 @@ class Vector2 implements Vector {
       (_v2storage[1] == other._v2storage[1]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v2storage);
+  int get hashCode => Object.hashAll(_v2storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -111,7 +111,7 @@ class Vector3 implements Vector {
       (_v3storage[2] == other._v3storage[2]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v3storage);
+  int get hashCode => Object.hashAll(_v3storage);
 
   /// Negate
   Vector3 operator -() => clone()..negate();

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -132,7 +132,7 @@ class Vector4 implements Vector {
       (_v4storage[3] == other._v4storage[3]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v4storage);
+  int get hashCode => Object.hashAll(_v4storage);
 
   /// Negate.
   Vector4 operator -() => clone()..negate();

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -153,7 +153,7 @@ class Matrix2 {
       (_m2storage[3] == other._m2storage[3]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m2storage);
+  int get hashCode => Object.hashAll(_m2storage);
 
   /// Returns row 0
   Vector2 get row0 => getRow(0);

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -249,7 +249,7 @@ class Matrix3 {
       (_m3storage[8] == other._m3storage[8]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m3storage);
+  int get hashCode => Object.hashAll(_m3storage);
 
   /// Returns row 0
   Vector3 get row0 => getRow(0);

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -541,7 +541,7 @@ class Matrix4 {
       (_m4storage[15] == other._m4storage[15]);
 
   @override
-  int get hashCode => quiver.hashObjects(_m4storage);
+  int get hashCode => Object.hashAll(_m4storage);
 
   /// Returns row 0
   Vector4 get row0 => getRow(0);

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -102,7 +102,7 @@ class Vector2 implements Vector {
       (_v2storage[1] == other._v2storage[1]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v2storage);
+  int get hashCode => Object.hashAll(_v2storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -111,7 +111,7 @@ class Vector3 implements Vector {
       (_v3storage[2] == other._v3storage[2]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v3storage);
+  int get hashCode => Object.hashAll(_v3storage);
 
   /// Negate
   Vector3 operator -() => clone()..negate();

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -132,7 +132,7 @@ class Vector4 implements Vector {
       (_v4storage[3] == other._v4storage[3]);
 
   @override
-  int get hashCode => quiver.hashObjects(_v4storage);
+  int get hashCode => Object.hashAll(_v4storage);
 
   /// Negate.
   Vector4 operator -() => clone()..negate();

--- a/lib/vector_math.dart
+++ b/lib/vector_math.dart
@@ -17,7 +17,6 @@ library vector_math;
 
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'hash.dart' as quiver;
 
 part 'src/vector_math/utilities.dart';
 part 'src/vector_math/aabb2.dart';

--- a/lib/vector_math_64.dart
+++ b/lib/vector_math_64.dart
@@ -17,7 +17,6 @@ library vector_math_64;
 
 import 'dart:math' as math;
 import 'dart:typed_data';
-import 'hash.dart' as quiver;
 
 part 'src/vector_math_64/utilities.dart';
 part 'src/vector_math_64/aabb2.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: vector_math
-version: 2.1.1-dev
+version: 2.1.1
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
   benchmark_harness: ^2.0.0


### PR DESCRIPTION
- Collapse pre-release versions in changelog
- Deprecate hash.dart library, prepare to release v2.1.1
