### PR TITLE
Use non-nullable parameters for operator ==

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.3-dev
+## 2.1.3
 
 - `operator ==` overrides no longer take nullable arguments. This is only
   visible for classes that implement the interfaces defined in this package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.1.3-dev
+
 ## 2.1.2
 
 - Fix to `Quad.copy` ([#221](https://github.com/google/vector_math.dart/issues/221))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.1.3-dev
 
+- `operator ==` overrides no longer take nullable arguments. This is only
+  visible for classes that implement the interfaces defined in this package
+  which no longer need to also widen the argument type.
+
 ## 2.1.2
 
 - Fix to `Quad.copy` ([#221](https://github.com/google/vector_math.dart/issues/221))

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -145,7 +145,7 @@ class Matrix2 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix2) &&
       (_m2storage[0] == other._m2storage[0]) &&
       (_m2storage[1] == other._m2storage[1]) &&

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -236,7 +236,7 @@ class Matrix3 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix3) &&
       (_m3storage[0] == other._m3storage[0]) &&
       (_m3storage[1] == other._m3storage[1]) &&

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -521,7 +521,7 @@ class Matrix4 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix4) &&
       (_m4storage[0] == other._m4storage[0]) &&
       (_m4storage[1] == other._m4storage[1]) &&

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -96,7 +96,7 @@ class Vector2 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector2) &&
       (_v2storage[0] == other._v2storage[0]) &&
       (_v2storage[1] == other._v2storage[1]);

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -104,7 +104,7 @@ class Vector3 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector3) &&
       (_v3storage[0] == other._v3storage[0]) &&
       (_v3storage[1] == other._v3storage[1]) &&

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -124,7 +124,7 @@ class Vector4 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector4) &&
       (_v4storage[0] == other._v4storage[0]) &&
       (_v4storage[1] == other._v4storage[1]) &&

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -145,7 +145,7 @@ class Matrix2 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix2) &&
       (_m2storage[0] == other._m2storage[0]) &&
       (_m2storage[1] == other._m2storage[1]) &&

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -236,7 +236,7 @@ class Matrix3 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix3) &&
       (_m3storage[0] == other._m3storage[0]) &&
       (_m3storage[1] == other._m3storage[1]) &&

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -521,7 +521,7 @@ class Matrix4 {
 
   /// Check if two matrices are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Matrix4) &&
       (_m4storage[0] == other._m4storage[0]) &&
       (_m4storage[1] == other._m4storage[1]) &&

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -96,7 +96,7 @@ class Vector2 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector2) &&
       (_v2storage[0] == other._v2storage[0]) &&
       (_v2storage[1] == other._v2storage[1]);

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -104,7 +104,7 @@ class Vector3 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector3) &&
       (_v3storage[0] == other._v3storage[0]) &&
       (_v3storage[1] == other._v3storage[1]) &&

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -124,7 +124,7 @@ class Vector4 implements Vector {
 
   /// Check if two vectors are the same.
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       (other is Vector4) &&
       (_v4storage[0] == other._v4storage[0]) &&
       (_v4storage[1] == other._v4storage[1]) &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.1.2
+version: 2.1.3-dev
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.1.3-dev
+version: 2.1.3
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 


### PR DESCRIPTION
The null value will never be passed to the equals operator
implementation. Widening the type causes any other class which
implements this interface to also widen the type.
