### PR TITLE
feat: include Vector and Matrix only constructors

### DIFF
--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -50,7 +50,7 @@ class Matrix2 {
     _m2storage[index(row, col)] = v;
   }
 
-  /// New matrix with the specified values.
+  /// New matrix with specified values.
   factory Matrix2(double arg0, double arg1, double arg2, double arg3) =>
       Matrix2.zero()..setValues(arg0, arg1, arg2, arg3);
 

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -54,6 +54,14 @@ class Matrix2 {
   factory Matrix2(double arg0, double arg1, double arg2, double arg3) =>
       Matrix2.zero()..setValues(arg0, arg1, arg2, arg3);
 
+  factory Matrix2.only({
+    double arg0 = 0,
+    double arg1 = 0,
+    double arg2 = 0,
+    double arg3 = 0,
+  }) =>
+      Matrix2.zero()..setValues(arg0, arg1, arg2, arg3);
+
   /// New matrix from [values].
   factory Matrix2.fromList(List<double> values) =>
       Matrix2.zero()..setValues(values[0], values[1], values[2], values[3]);

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -50,10 +50,11 @@ class Matrix2 {
     _m2storage[index(row, col)] = v;
   }
 
-  /// New matrix with specified values.
+  /// New matrix with the specified values.
   factory Matrix2(double arg0, double arg1, double arg2, double arg3) =>
       Matrix2.zero()..setValues(arg0, arg1, arg2, arg3);
 
+  /// New matrix only with the specified values.
   factory Matrix2.only({
     double arg0 = 0,
     double arg1 = 0,

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -104,7 +104,7 @@ class Matrix3 {
       Matrix3.zero()
         ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 
-  /// New matrix only with specified values.
+  /// New matrix only with the specified values.
   factory Matrix3.only({
     double arg0 = 0,
     double arg1 = 0,

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -104,6 +104,21 @@ class Matrix3 {
       Matrix3.zero()
         ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
 
+  /// New matrix only with specified values.
+  factory Matrix3.only({
+    double arg0 = 0,
+    double arg1 = 0,
+    double arg2 = 0,
+    double arg3 = 0,
+    double arg4 = 0,
+    double arg5 = 0,
+    double arg6 = 0,
+    double arg7 = 0,
+    double arg8 = 0,
+  }) =>
+      Matrix3.zero()
+        ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+
   /// New matrix from [values].
   factory Matrix3.fromList(List<double> values) => Matrix3.zero()
     ..setValues(values[0], values[1], values[2], values[3], values[4],

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -200,7 +200,7 @@ class Matrix4 {
         ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
             arg10, arg11, arg12, arg13, arg14, arg15);
 
-  /// Constructs a new mat4 only with specified values.
+  /// New matrix only with the specified values.
   factory Matrix4.only({
     double arg0 = 0,
     double arg1 = 0,

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -200,6 +200,29 @@ class Matrix4 {
         ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
             arg10, arg11, arg12, arg13, arg14, arg15);
 
+  /// Constructs a new mat4 only with specified values.
+  factory Matrix4.only({
+    double arg0 = 0,
+    double arg1 = 0,
+    double arg2 = 0,
+    double arg3 = 0,
+    double arg4 = 0,
+    double arg5 = 0,
+    double arg6 = 0,
+    double arg7 = 0,
+    double arg8 = 0,
+    double arg9 = 0,
+    double arg10 = 0,
+    double arg11 = 0,
+    double arg12 = 0,
+    double arg13 = 0,
+    double arg14 = 0,
+    double arg15 = 0,
+  }) =>
+      Matrix4.zero()
+        ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+            arg10, arg11, arg12, arg13, arg14, arg15);
+
   /// New matrix from [values].
   factory Matrix4.fromList(List<double> values) => Matrix4.zero()
     ..setValues(

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -37,6 +37,10 @@ class Vector2 implements Vector {
   /// Construct a new vector with the specified values.
   factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
 
+  /// Construct a new vector only with the specified values.
+  factory Vector2.only({double x = 0, double y = 0}) =>
+      Vector2.zero()..setValues(x, y);
+
   /// Initialized with values from [array] starting at [offset].
   factory Vector2.array(List<double> array, [int offset = 0]) =>
       Vector2.zero()..copyFromArray(array, offset);

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -41,6 +41,10 @@ class Vector3 implements Vector {
   factory Vector3(double x, double y, double z) =>
       Vector3.zero()..setValues(x, y, z);
 
+  /// Construct a new vector only with the specified values.
+  factory Vector3.only({double x = 0, double y = 0, double z = 0}) =>
+      Vector3.zero()..setValues(x, y, z);
+
   /// Initialized with values from [array] starting at [offset].
   factory Vector3.array(List<double> array, [int offset = 0]) =>
       Vector3.zero()..copyFromArray(array, offset);

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -44,6 +44,15 @@ class Vector4 implements Vector {
   factory Vector4(double x, double y, double z, double w) =>
       Vector4.zero()..setValues(x, y, z, w);
 
+  /// Construct a new vector only with the specified values.
+  factory Vector4.only({
+    double x = 0,
+    double y = 0,
+    double z = 0,
+    double w = 0,
+  }) =>
+      Vector4.zero()..setValues(x, y, z, w);
+
   /// Initialized with values from [array] starting at [offset].
   factory Vector4.array(List<double> array, [int offset = 0]) =>
       Vector4.zero()..copyFromArray(array, offset);

--- a/test/matrix2_test.dart
+++ b/test/matrix2_test.dart
@@ -120,10 +120,53 @@ void testMatrix2Equals() {
   expect(Matrix2.identity().hashCode, equals(Matrix2.identity().hashCode));
 }
 
+void testMatrix2Constructor() {
+  final m = Matrix2(1.0, 2.0, 3.0, 4.0);
+  expect(m.storage[0], equals(1.0));
+  expect(m.storage[1], equals(2.0));
+  expect(m.storage[2], equals(3.0));
+  expect(m.storage[3], equals(4.0));
+}
+
+void testMatrix2OnlyConstructor() {
+  const size = 4;
+
+  final m = Matrix2.only();
+  for (var i = 0; i < size; i++) {
+    expect(m.storage[i], equals(0.0));
+  }
+
+  final m2 = Matrix2.only(arg0: 1.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 0 ? 1.0 : 0.0;
+    expect(m2.storage[i], equals(expected));
+  }
+
+  final m3 = Matrix2.only(arg1: 2.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 1 ? 2.0 : 0.0;
+    expect(m3.storage[i], equals(expected));
+  }
+
+  final m4 = Matrix2.only(arg2: 3.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 2 ? 3.0 : 0.0;
+    expect(m4.storage[i], equals(expected));
+  }
+
+  final m5 = Matrix2.only(arg3: 4.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 3 ? 4.0 : 0.0;
+    expect(m5.storage[i], equals(expected));
+  }
+}
+
 void main() {
   group('Matrix2', () {
     test('Determinant', testMatrix2Determinant);
     test('Adjoint', testMatrix2Adjoint);
+    test('Constructor', testMatrix2Constructor);
+    test('only constructor', testMatrix2OnlyConstructor);
     test('transform 2D', testMatrix2Transform);
     test('inversion', testMatrix2Inversion);
     test('dot product', testMatrix2Dot);

--- a/test/matrix3_test.dart
+++ b/test/matrix3_test.dart
@@ -242,6 +242,69 @@ void testMatrix3ConstructorCopy() {
   expect(m.entry(2, 2), 9.0);
 }
 
+void testMatrix3OnlyConstructor() {
+  const size = 9;
+
+  final m = Matrix3.only();
+  for (var i = 0; i < size; i++) {
+    expect(m.storage[i], equals(0.0));
+  }
+
+  final m2 = Matrix3.only(arg0: 1.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 0 ? 1.0 : 0.0;
+    expect(m2.storage[i], equals(expected));
+  }
+
+  final m3 = Matrix3.only(arg1: 2.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 1 ? 2.0 : 0.0;
+    expect(m3.storage[i], equals(expected));
+  }
+
+  final m4 = Matrix3.only(arg2: 3.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 2 ? 3.0 : 0.0;
+    expect(m4.storage[i], equals(expected));
+  }
+
+  final m5 = Matrix3.only(arg3: 4.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 3 ? 4.0 : 0.0;
+    expect(m5.storage[i], equals(expected));
+  }
+
+  final m6 = Matrix3.only(arg4: 5.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 4 ? 5.0 : 0.0;
+    expect(m6.storage[i], equals(expected));
+  }
+
+  final m7 = Matrix3.only(arg5: 6.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 5 ? 6.0 : 0.0;
+    expect(m7.storage[i], equals(expected));
+  }
+
+  final m8 = Matrix3.only(arg6: 7.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 6 ? 7.0 : 0.0;
+    expect(m8.storage[i], equals(expected));
+  }
+
+  final m9 = Matrix3.only(arg7: 8.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 7 ? 8.0 : 0.0;
+    expect(m9.storage[i], equals(expected));
+  }
+
+  final m10 = Matrix3.only(arg8: 9.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 8 ? 9.0 : 0.0;
+    expect(m10.storage[i], equals(expected));
+  }
+}
+
 void testMatrix3Inversion() {
   final m = Matrix3(1.0, 0.0, 5.0, 2.0, 1.0, 6.0, 3.0, 4.0, 0.0);
   final result = Matrix3.zero();
@@ -334,6 +397,7 @@ void main() {
     test('rotation 2D', testMatrix3AbsoluteRotate2);
     test('transform', testMatrix3Transform);
     test('constructor', testMatrix3ConstructorCopy);
+    test('only constructor', testMatrix3OnlyConstructor);
     test('inversion', testMatrix3Inversion);
     test('dot product', testMatrix3Dot);
     test('Scale', testMatrix3Scale);

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -598,6 +598,111 @@ void testMatrix4InvertConstructor() {
   expect(Matrix4.inverted(Matrix4.identity()), equals(Matrix4.identity()));
 }
 
+void testMatrix4OnlyConstructor() {
+  const size = 16;
+
+  final m = Matrix4.only();
+  for (var i = 0; i < size; i++) {
+    expect(m.storage[i], equals(0.0));
+  }
+
+  final m2 = Matrix4.only(arg0: 1.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 0 ? 1.0 : 0.0;
+    expect(m2.storage[i], equals(expected));
+  }
+
+  final m3 = Matrix4.only(arg1: 2.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 1 ? 2.0 : 0.0;
+    expect(m3.storage[i], equals(expected));
+  }
+
+  final m4 = Matrix4.only(arg2: 3.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 2 ? 3.0 : 0.0;
+    expect(m4.storage[i], equals(expected));
+  }
+
+  final m5 = Matrix4.only(arg3: 4.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 3 ? 4.0 : 0.0;
+    expect(m5.storage[i], equals(expected));
+  }
+
+  final m6 = Matrix4.only(arg4: 5.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 4 ? 5.0 : 0.0;
+    expect(m6.storage[i], equals(expected));
+  }
+
+  final m7 = Matrix4.only(arg5: 6.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 5 ? 6.0 : 0.0;
+    expect(m7.storage[i], equals(expected));
+  }
+
+  final m8 = Matrix4.only(arg6: 7.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 6 ? 7.0 : 0.0;
+    expect(m8.storage[i], equals(expected));
+  }
+
+  final m9 = Matrix4.only(arg7: 8.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 7 ? 8.0 : 0.0;
+    expect(m9.storage[i], equals(expected));
+  }
+
+  final m10 = Matrix4.only(arg8: 9.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 8 ? 9.0 : 0.0;
+    expect(m10.storage[i], equals(expected));
+  }
+
+  final m11 = Matrix4.only(arg9: 10.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 9 ? 10.0 : 0.0;
+    expect(m11.storage[i], equals(expected));
+  }
+
+  final m12 = Matrix4.only(arg10: 11.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 10 ? 11.0 : 0.0;
+    expect(m12.storage[i], equals(expected));
+  }
+
+  final m13 = Matrix4.only(arg11: 12.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 11 ? 12.0 : 0.0;
+    expect(m13.storage[i], equals(expected));
+  }
+
+  final m14 = Matrix4.only(arg12: 13.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 12 ? 13.0 : 0.0;
+    expect(m14.storage[i], equals(expected));
+  }
+
+  final m15 = Matrix4.only(arg13: 14.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 13 ? 14.0 : 0.0;
+    expect(m15.storage[i], equals(expected));
+  }
+
+  final m16 = Matrix4.only(arg14: 15.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 14 ? 15.0 : 0.0;
+    expect(m16.storage[i], equals(expected));
+  }
+
+  final m17 = Matrix4.only(arg15: 16.0);
+  for (var i = 0; i < size; i++) {
+    final expected = i == 15 ? 16.0 : 0.0;
+    expect(m17.storage[i], equals(expected));
+  }
+}
+
 void testMatrix4tryInvert() {
   expect(Matrix4.tryInvert(Matrix4.zero()), isNull);
   expect(Matrix4.tryInvert(Matrix4.identity()), equals(Matrix4.identity()));
@@ -691,6 +796,7 @@ void main() {
     test('compose/decompose', testMatrix4Compose);
     test('equals', testMatrix4Equals);
     test('invert constructor', testMatrix4InvertConstructor);
+    test('only constructor', testMatrix4OnlyConstructor);
     test('tryInvert', testMatrix4tryInvert);
     test('skew constructor', testMatrix4SkewConstructor);
     test('leftTranslate', testLeftTranslate);

--- a/test/vector2_test.dart
+++ b/test/vector2_test.dart
@@ -149,6 +149,20 @@ void testVector2Constructor() {
   expect(v3.y, lessThanOrEqualTo(1.0));
 }
 
+void testVector2OnlyConstructor() {
+  final v1 = Vector2.only();
+  expect(v1.x, equals(0.0));
+  expect(v1.y, equals(0.0));
+
+  final v2 = Vector2.only(x: 2.0);
+  expect(v2.x, equals(2.0));
+  expect(v2.y, equals(0.0));
+
+  final v3 = Vector2.only(y: 4.0);
+  expect(v3.x, equals(0.0));
+  expect(v3.y, equals(4.0));
+}
+
 void testVector2Length() {
   final a = Vector2(5.0, 7.0);
 
@@ -345,6 +359,7 @@ void main() {
     test('set length', testVector2SetLength);
     test('Negate', testVector2Negate);
     test('Constructor', testVector2Constructor);
+    test('only constructor', testVector2OnlyConstructor);
     test('add', testVector2Add);
     test('min/max', testVector2MinMax);
     test('mix', testVector2Mix);

--- a/test/vector3_test.dart
+++ b/test/vector3_test.dart
@@ -204,6 +204,28 @@ void testVector3Constructor() {
   expect(v3.z, lessThanOrEqualTo(1.0));
 }
 
+void testVector3OnlyConstructor() {
+  final v1 = Vector3.only();
+  expect(v1.x, equals(0.0));
+  expect(v1.y, equals(0.0));
+  expect(v1.z, equals(0.0));
+
+  final v2 = Vector3.only(x: 2.0);
+  expect(v2.x, equals(2.0));
+  expect(v2.y, equals(0.0));
+  expect(v2.z, equals(0.0));
+
+  final v3 = Vector3.only(y: 4.0);
+  expect(v3.x, equals(0.0));
+  expect(v3.y, equals(4.0));
+  expect(v3.z, equals(0.0));
+
+  final v4 = Vector3.only(z: -1.5);
+  expect(v4.x, equals(0.0));
+  expect(v4.y, equals(0.0));
+  expect(v4.z, equals(-1.5));
+}
+
 void testVector3Length() {
   final a = Vector3(5.0, 7.0, 3.0);
 
@@ -453,6 +475,7 @@ void main() {
     test('set length', testVector3SetLength);
     test('Negate', testVector3Negate);
     test('Constructor', testVector3Constructor);
+    test('only constructor', testVector3OnlyConstructor);
     test('add', testVector3Add);
     test('min/max', testVector3MinMax);
     test('mix', testVector3Mix);

--- a/test/vector4_test.dart
+++ b/test/vector4_test.dart
@@ -122,6 +122,38 @@ void testVector4Constructor() {
   expect(v3.w, lessThanOrEqualTo(1.0));
 }
 
+void testVector4OnlyConstructor() {
+  final v1 = Vector4.only();
+  expect(v1.x, equals(0.0));
+  expect(v1.y, equals(0.0));
+  expect(v1.z, equals(0.0));
+  expect(v1.w, equals(0.0));
+
+  final v2 = Vector4.only(x: 2.0);
+  expect(v2.x, equals(2.0));
+  expect(v2.y, equals(0.0));
+  expect(v2.z, equals(0.0));
+  expect(v2.w, equals(0.0));
+
+  final v3 = Vector4.only(y: 4.0);
+  expect(v3.x, equals(0.0));
+  expect(v3.y, equals(4.0));
+  expect(v3.z, equals(0.0));
+  expect(v3.w, equals(0.0));
+
+  final v4 = Vector4.only(z: -1.5);
+  expect(v4.x, equals(0.0));
+  expect(v4.y, equals(0.0));
+  expect(v4.z, equals(-1.5));
+  expect(v4.w, equals(0.0));
+
+  final v5 = Vector4.only(w: 10.0);
+  expect(v5.x, equals(0.0));
+  expect(v5.y, equals(0.0));
+  expect(v5.z, equals(0.0));
+  expect(v5.w, equals(10.0));
+}
+
 void testVector4Length() {
   final a = Vector4(5.0, 7.0, 3.0, 10.0);
 
@@ -271,6 +303,7 @@ void main() {
     test('set length', testVector4SetLength);
     test('Negate', testVector4Negate);
     test('Constructor', testVector4Constructor);
+    test('only constructor', testVector4OnlyConstructor);
     test('add', testVector4Add);
     test('min/max', testVector4MinMax);
     test('mix', testVector4Mix);


### PR DESCRIPTION
## Description
Adds `only` constructor to Vector2, Vector3, Vector4, Matrix2, Matrix3 and Matrix4 to allow specifying some values instead of all of them.

## Why?
Is sometimes very inconvenient and verbose to create Vectors and Matrices.

The only constructor aims to improve the developer experience.

```dart
// Before:
Vector4(0, 0, 1, 0);

/// After:
Vector4.only(z: 1);
```

### Other proposals
1)
Perhaps, and this may be done and discussed in another PR, one could add a default optional parameter to allow the following:

```dart
// Before:
Vector4(3, 3, 1, 3);

// After:
Vector4.only(z: 1, default: 3); 
```

Which, for example, comes in handy when using Matrix4, since it has a total of 16 arguments.

2)
Add a `copyWith` method to Matrix classes to allow doing:
```dart
Matrix4.identity().copytWith(arg8: 3);
```

It would return the same object since Matrix is mutable. Perhaps another name can be found to avoid this confusion since Flutter developers are used to immutability and may expect a new Matrix object to be returned.

## Additional context

This change was Inspired by [ZVector](https://github.com/jamesblasco/zflutter/blob/e3c0fcfec6142c8655264a3886ced58d2cee5556/zflutter/lib/src/core/core.dart#L29) from ZFlutter. 

This change is similar to [EdgeInsets](https://github.com/flutter/flutter/blob/b0aa50255b117dd6afd178ddae7f0c7b4a01dc11/packages/flutter/lib/src/painting/edge_insets.dart#L377) from Flutter. Meaning that Flutter developers will be already familiar with this constructor. 

This can be useful for users of the Flame library since Flame depends on this [package](https://github.com/flame-engine/flame/blob/ad602ff9634e248f7b3b385ee000d95131ea0a60/packages/flame/pubspec.yaml#L16).
