### PR TITLE
feat: included Matrix value setters

### DIFF
--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -78,6 +78,18 @@ class Matrix2 {
   factory Matrix2.rotation(double radians) =>
       Matrix2.zero()..setRotation(radians);
 
+  /// Sets the value for row 0 and column 0.
+  set r0c0(double value) => _m2storage[index(0, 0)] = value;
+
+  /// Sets the value for row 0 and column 1.
+  set r0c1(double value) => _m2storage[index(0, 1)] = value;
+
+  /// Sets the value for row 1 and column 0.
+  set r1c0(double value) => _m2storage[index(1, 0)] = value;
+
+  /// Sets the value for row 1 and column 1.
+  set r1c1(double value) => _m2storage[index(1, 1)] = value;
+
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3) {
     _m2storage[3] = arg3;

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -79,16 +79,16 @@ class Matrix2 {
       Matrix2.zero()..setRotation(radians);
 
   /// Sets the value for row 0 and column 0.
-  set r0c0(double value) => _m2storage[index(0, 0)] = value;
+  set r0c0(double value) => _m2storage[0] = value;
 
   /// Sets the value for row 0 and column 1.
-  set r0c1(double value) => _m2storage[index(0, 1)] = value;
+  set r0c1(double value) => _m2storage[2] = value;
 
   /// Sets the value for row 1 and column 0.
-  set r1c0(double value) => _m2storage[index(1, 0)] = value;
+  set r1c0(double value) => _m2storage[1] = value;
 
   /// Sets the value for row 1 and column 1.
-  set r1c1(double value) => _m2storage[index(1, 1)] = value;
+  set r1c1(double value) => _m2storage[3] = value;
 
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3) {

--- a/test/matrix2_test.dart
+++ b/test/matrix2_test.dart
@@ -130,5 +130,55 @@ void main() {
     test('Scale', testMatrix2Scale);
     test('solving', testMatrix2Solving);
     test('equals', testMatrix2Equals);
+
+    group('value setter', () {
+      test('r0c0 sets', () {
+        final m = Matrix2.zero();
+        const newValue = 2.0;
+
+        m.r0c0 = newValue;
+
+        expect(m.entry(0, 0), equals(newValue));
+        expect(m.entry(0, 1), equals(0.0));
+        expect(m.entry(1, 0), equals(0.0));
+        expect(m.entry(1, 1), equals(0.0));
+      });
+
+      test('r0c1 sets', () {
+        final m = Matrix2.zero();
+        const newValue = 2.0;
+
+        m.r0c1 = newValue;
+
+        expect(m.entry(0, 0), equals(0.0));
+        expect(m.entry(0, 1), equals(newValue));
+        expect(m.entry(1, 0), equals(0.0));
+        expect(m.entry(1, 1), equals(0.0));
+      });
+
+      test('r1c0 sets', () {
+        final m = Matrix2.zero();
+        const newValue = 2.0;
+
+        m.r1c0 = newValue;
+
+        expect(m.entry(0, 0), equals(0.0));
+        expect(m.entry(0, 1), equals(0.0));
+        expect(m.entry(1, 0), equals(newValue));
+        expect(m.entry(1, 1), equals(0.0));
+      });
+
+      test('r1c1 sets', () {
+        final m = Matrix2.zero();
+        const newValue = 2.0;
+
+        m.r1c1 = newValue;
+
+        expect(m.entry(0, 0), equals(0.0));
+        expect(m.entry(0, 1), equals(0.0));
+        expect(m.entry(1, 0), equals(0.0));
+        expect(m.entry(1, 1), equals(newValue));
+      });
+    });
   });
 }


### PR DESCRIPTION
**_STATUS: Draft_**

## Description

Adds setters `r0c0`, `r0c1`, `r1c0` and `r1c1` to `Matrix2`, `Matrix3` and `Matrix4`.

```dart
final m = Matrix2.zero()..r0c0 = 2;

/*
[ 2, 0 ]
[ 0, 0 ]
*/
```

## Why?

Sometimes it is very inconvenient and verbose to create Matrices.

The value setters aim to improve the developer experience.

```dart
// Before:
Matrix4(2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);

/// After:
Matrix4.zero()..r0c0 = 2;
```

## Additional Context
#265 
https://github.com/google/vector_math.dart/pull/265#discussion_r891894677
https://github.com/google/vector_math.dart/pull/265#issuecomment-1149507992