### PR TITLE
deprecate the SimplexNoise classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - `operator ==` overrides no longer take nullable arguments. This is only
   visible for classes that implement the interfaces defined in this package
   which no longer need to also widen the argument type.
+- Deprecate `SimplexNoise`; see https:github.com/google/vector_math.dart/issues/270
+  for more information.
 
 ## 2.1.2
 

--- a/README.md
+++ b/README.md
@@ -163,4 +163,3 @@ To automatically generate the latest version of ```vector_math_64```:
 ```
 ~/src/vector_math/> dart tool/generate_vector_math_64.dart
 ```
-

--- a/lib/src/vector_math/third_party/noise.dart
+++ b/lib/src/vector_math/third_party/noise.dart
@@ -26,6 +26,8 @@ part of vector_math;
  * found at: http://webstaff.itn.liu.se/~stegu/simplexnoise/SimplexNoise.java
  */
 
+@Deprecated('This API will be removed '
+    '(see https:github.com/google/vector_math.dart/issues/270)')
 class SimplexNoise {
   static final List<List<double>> _grad3 = <List<double>>[
     <double>[1.0, 1.0, 0.0],

--- a/lib/src/vector_math_64/third_party/noise.dart
+++ b/lib/src/vector_math_64/third_party/noise.dart
@@ -25,7 +25,8 @@ part of vector_math_64;
  * This is based on the implementation of Simplex Noise by Stefan Gustavson
  * found at: http://webstaff.itn.liu.se/~stegu/simplexnoise/SimplexNoise.java
  */
-
+@Deprecated('This API will be removed '
+    '(see https:github.com/google/vector_math.dart/issues/270)')
 class SimplexNoise {
   static final List<List<double>> _grad3 = <List<double>>[
     <double>[1.0, 1.0, 0.0],

--- a/lib/vector_math.dart
+++ b/lib/vector_math.dart
@@ -11,8 +11,8 @@
 /// [Quad], [Ray], [Sphere] and [Triangle]).
 ///
 /// In addition some utilities are available as color operations (See [Colors]
-/// class), noise generators ([SimplexNoise]) and common OpenGL operations
-/// (like [makeViewMatrix], [makePerspectiveMatrix], or [pickRay]).
+/// class) and common OpenGL operations (like [makeViewMatrix],
+/// [makePerspectiveMatrix], or [pickRay]).
 library vector_math;
 
 import 'dart:math' as math;

--- a/lib/vector_math_64.dart
+++ b/lib/vector_math_64.dart
@@ -11,8 +11,8 @@
 /// [Quad], [Ray], [Sphere] and [Triangle]).
 ///
 /// In addition some utilities are available as color operations (See [Colors]
-/// class), noise generators ([SimplexNoise]) and common OpenGL operations
-/// (like [makeViewMatrix], [makePerspectiveMatrix], or [pickRay]).
+/// class) and common OpenGL operations (like [makeViewMatrix],
+/// [makePerspectiveMatrix], or [pickRay]).
 library vector_math_64;
 
 import 'dart:math' as math;

--- a/test/noise_test.dart
+++ b/test/noise_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:test/test.dart';
 
 import 'package:vector_math/vector_math.dart';


### PR DESCRIPTION
- deprecate the two SimplexNoise classes
- update the changelog entry for `2.1.3` (which has not yet been published)

This is work towards https://github.com/google/vector_math.dart/issues/270; deprecating and eventually removing the SimplexNoise classes.