### PR TITLE
Update vector2.dart

### DIFF
--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -158,6 +158,7 @@ class Vector2 implements Vector {
   double normalize() {
     final l = length;
     if (l == 0.0) {
+      print('Fix for flutter here'); // added to fix flutter crash 
       return 0.0;
     }
     final d = 1.0 / l;


### PR DESCRIPTION
fix for flutter 3.7.0 crash
When using Confetti addon - it crashs unless this print line is added