### PR TITLE
Use `Vector2.storage` directly instead of `_v2storage`

### DIFF
--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -88,8 +88,8 @@ class Matrix2 {
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector2 arg0, Vector2 arg1) {
-    final arg0Storage = arg0._v2storage;
-    final arg1Storage = arg1._v2storage;
+    final arg0Storage = arg0.storage;
+    final arg1Storage = arg1.storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
@@ -107,8 +107,8 @@ class Matrix2 {
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector2 u, Vector2 v) {
-    final uStorage = u._v2storage;
-    final vStorage = v._v2storage;
+    final uStorage = u.storage;
+    final vStorage = v.storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
@@ -123,7 +123,7 @@ class Matrix2 {
 
   /// Sets the diagonal of the matrix to be [arg].
   void setDiagonal(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
   }
@@ -169,7 +169,7 @@ class Matrix2 {
 
   /// Sets [row] of the matrix to values in [arg]
   void setRow(int row, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[index(row, 0)] = argStorage[0];
     _m2storage[index(row, 1)] = argStorage[1];
   }
@@ -177,7 +177,7 @@ class Matrix2 {
   /// Gets the [row] of the matrix
   Vector2 getRow(int row) {
     final r = Vector2.zero();
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[0] = _m2storage[index(row, 0)];
     rStorage[1] = _m2storage[index(row, 1)];
     return r;
@@ -185,7 +185,7 @@ class Matrix2 {
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final entry = column * 2;
     _m2storage[entry + 1] = argStorage[1];
     _m2storage[entry + 0] = argStorage[0];
@@ -195,7 +195,7 @@ class Matrix2 {
   Vector2 getColumn(int column) {
     final r = Vector2.zero();
     final entry = column * 2;
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[1] = _m2storage[entry + 1];
     rStorage[0] = _m2storage[entry + 0];
     return r;
@@ -279,13 +279,13 @@ class Matrix2 {
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[i] * vStorage[0] + _m2storage[2 + i] * vStorage[1];
   }
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[j * 2] * vStorage[0] +
         _m2storage[(j * 2) + 1] * vStorage[1];
   }
@@ -468,7 +468,7 @@ class Matrix2 {
   /// Transform [arg] of type [Vector2] using the transformation defined by
   /// this.
   Vector2 transform(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = (_m2storage[0] * argStorage[0]) + (_m2storage[2] * argStorage[1]);
     final y = (_m2storage[1] * argStorage[0]) + (_m2storage[3] * argStorage[1]);
     argStorage[0] = x;

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -633,7 +633,7 @@ class Matrix3 {
     final m01 = _m3storage[3].abs();
     final m10 = _m3storage[1].abs();
     final m11 = _m3storage[4].abs();
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = argStorage[0];
     final y = argStorage[1];
     argStorage[0] = x * m00 + y * m01;
@@ -643,7 +643,7 @@ class Matrix3 {
 
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x_ = (_m3storage[0] * argStorage[0]) +
         (_m3storage[3] * argStorage[1]) +
         _m3storage[6];

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -68,36 +68,36 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    this[0] = x_;
-    this[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    this[0] = 0.0;
-    this[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    this[0] = other[0];
-    this[1] = other[1];
+    storage[0] = other[0];
+    storage[1] = other[1];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    this[0] = arg;
-    this[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${this[0]},${this[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      other is Vector2 && this[0] == other[0] && this[1] == other[1];
+      other is Vector2 && storage[0] == other[0] && storage[1] == other[1];
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -136,8 +136,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      this[0] *= l;
-      this[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -145,7 +145,7 @@ class Vector2 implements Vector {
   double get length => math.sqrt(length2);
 
   /// Length squared.
-  double get length2 => this[0] * this[0] + this[1] * this[1];
+  double get length2 => storage[0] * storage[0] + storage[1] * storage[1];
 
   /// Normalize this.
   double normalize() {
@@ -154,8 +154,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    this[0] *= d;
-    this[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -188,7 +188,7 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    if (this[0] == other[0] && this[1] == other[1]) {
+    if (storage[0] == other[0] && storage[1] == other[1]) {
       return 0.0;
     }
 
@@ -199,7 +199,7 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    if (this[0] == other[0] && this[1] == other[1]) {
+    if (storage[0] == other[0] && storage[1] == other[1]) {
       return 0.0;
     }
 
@@ -210,7 +210,7 @@ class Vector2 implements Vector {
   }
 
   /// Inner product.
-  double dot(Vector2 other) => this[0] * other[0] + this[1] * other[1];
+  double dot(Vector2 other) => storage[0] * other[0] + storage[1] * other[1];
 
   /// Transforms this into the product of this as a row vector,
   /// postmultiplied by matrix, [arg].
@@ -218,20 +218,20 @@ class Vector2 implements Vector {
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    final v0 = this[0];
-    final v1 = this[1];
-    this[0] = v0 * arg[0] + v1 * arg[1];
-    this[1] = v0 * arg[2] + v1 * arg[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * arg[0] + v1 * arg[1];
+    storage[1] = v0 * arg[2] + v1 * arg[3];
   }
 
   /// Cross product.
-  double cross(Vector2 other) => this[0] * other[1] - this[1] * other[0];
+  double cross(Vector2 other) => storage[0] * other[1] - storage[1] * other[0];
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * this[1], scale * this[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -251,45 +251,45 @@ class Vector2 implements Vector {
   double absoluteError(Vector2 correct) => (this - correct).length;
 
   /// True if any component is infinite.
-  bool get isInfinite => this[0].isInfinite || this[1].isInfinite;
+  bool get isInfinite => storage[0].isInfinite || storage[1].isInfinite;
 
   /// True if any component is NaN.
-  bool get isNaN => this[0].isNaN || this[1].isNaN;
+  bool get isNaN => storage[0].isNaN || storage[1].isNaN;
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    this[0] += arg[0];
-    this[1] += arg[1];
+    storage[0] += arg[0];
+    storage[1] += arg[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    this[0] += arg[0] * factor;
-    this[1] += arg[1] * factor;
+    storage[0] += arg[0] * factor;
+    storage[1] += arg[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    this[0] -= arg[0];
-    this[1] -= arg[1];
+    storage[0] -= arg[0];
+    storage[1] -= arg[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    this[0] *= arg[0];
-    this[1] *= arg[1];
+    storage[0] *= arg[0];
+    storage[1] *= arg[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    this[0] /= arg[0];
-    this[1] /= arg[1];
+    storage[0] /= arg[0];
+    storage[1] /= arg[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    this[0] *= arg;
-    this[1] *= arg;
+    storage[0] *= arg;
+    storage[1] *= arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -297,50 +297,54 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    this[0] *= -1;
-    this[1] *= -1;
+    storage[0] *= -1;
+    storage[1] *= -1;
   }
 
   /// Absolute value.
   void absolute() {
-    this[0] = this[0].abs();
-    this[1] = this[1].abs();
+    storage[0] = storage[0].abs();
+    storage[1] = storage[1].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
-    this[0] = this[0].clamp(min[0], max[0]).toDouble();
-    this[1] = this[1].clamp(min[1], max[1]).toDouble();
+    storage[0] = storage[0].clamp(min[0], max[0]).toDouble();
+    storage[1] = storage[1].clamp(min[1], max[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    this[0] = this[0].clamp(min, max).toDouble();
-    this[1] = this[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    this[0] = this[0].floorToDouble();
-    this[1] = this[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    this[0] = this[0].ceilToDouble();
-    this[1] = this[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    this[0] = this[0].roundToDouble();
-    this[1] = this[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    this[0] = this[0] < 0.0 ? this[0].ceilToDouble() : this[0].floorToDouble();
-    this[1] = this[1] < 0.0 ? this[1].ceilToDouble() : this[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -348,77 +352,77 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    arg[0] = this[0];
-    arg[1] = this[1];
+    arg[0] = storage[0];
+    arg[1] = storage[1];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 0] = this[0];
-    array[offset + 1] = this[1];
+    array[offset + 0] = storage[0];
+    array[offset + 1] = storage[1];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    this[0] = array[offset + 0];
-    this[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
   }
 
   set xy(Vector2 arg) {
-    this[0] = arg[0];
-    this[1] = arg[1];
+    storage[0] = arg[0];
+    storage[1] = arg[1];
   }
 
   set yx(Vector2 arg) {
-    this[0] = arg[1];
-    this[1] = arg[0];
+    storage[0] = arg[1];
+    storage[1] = arg[0];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => this[0] = arg;
-  set y(double arg) => this[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(this[0], this[0]);
-  Vector2 get xy => Vector2(this[0], this[1]);
-  Vector2 get yx => Vector2(this[1], this[0]);
-  Vector2 get yy => Vector2(this[1], this[1]);
-  Vector3 get xxx => Vector3(this[0], this[0], this[0]);
-  Vector3 get xxy => Vector3(this[0], this[0], this[1]);
-  Vector3 get xyx => Vector3(this[0], this[1], this[0]);
-  Vector3 get xyy => Vector3(this[0], this[1], this[1]);
-  Vector3 get yxx => Vector3(this[1], this[0], this[0]);
-  Vector3 get yxy => Vector3(this[1], this[0], this[1]);
-  Vector3 get yyx => Vector3(this[1], this[1], this[0]);
-  Vector3 get yyy => Vector3(this[1], this[1], this[1]);
-  Vector4 get xxxx => Vector4(this[0], this[0], this[0], this[0]);
-  Vector4 get xxxy => Vector4(this[0], this[0], this[0], this[1]);
-  Vector4 get xxyx => Vector4(this[0], this[0], this[1], this[0]);
-  Vector4 get xxyy => Vector4(this[0], this[0], this[1], this[1]);
-  Vector4 get xyxx => Vector4(this[0], this[1], this[0], this[0]);
-  Vector4 get xyxy => Vector4(this[0], this[1], this[0], this[1]);
-  Vector4 get xyyx => Vector4(this[0], this[1], this[1], this[0]);
-  Vector4 get xyyy => Vector4(this[0], this[1], this[1], this[1]);
-  Vector4 get yxxx => Vector4(this[1], this[0], this[0], this[0]);
-  Vector4 get yxxy => Vector4(this[1], this[0], this[0], this[1]);
-  Vector4 get yxyx => Vector4(this[1], this[0], this[1], this[0]);
-  Vector4 get yxyy => Vector4(this[1], this[0], this[1], this[1]);
-  Vector4 get yyxx => Vector4(this[1], this[1], this[0], this[0]);
-  Vector4 get yyxy => Vector4(this[1], this[1], this[0], this[1]);
-  Vector4 get yyyx => Vector4(this[1], this[1], this[1], this[0]);
-  Vector4 get yyyy => Vector4(this[1], this[1], this[1], this[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => this[0];
-  double get y => this[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -68,39 +68,36 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    storage[0] = x_;
-    storage[1] = y_;
+    this[0] = x_;
+    this[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
+    this[0] = 0.0;
+    this[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other.storage;
-    storage[1] = otherStorage[1];
-    storage[0] = otherStorage[0];
+    this[0] = other[0];
+    this[1] = other[1];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    storage[0] = arg;
-    storage[1] = arg;
+    this[0] = arg;
+    this[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${storage[0]},${storage[1]}]';
+  String toString() => '[${this[0]},${this[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      (other is Vector2) &&
-      (storage[0] == other.storage[0]) &&
-      (storage[1] == other.storage[1]);
+      other is Vector2 && this[0] == other[0] && this[1] == other[1];
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -139,8 +136,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      storage[0] *= l;
-      storage[1] *= l;
+      this[0] *= l;
+      this[1] *= l;
     }
   }
 
@@ -148,12 +145,7 @@ class Vector2 implements Vector {
   double get length => math.sqrt(length2);
 
   /// Length squared.
-  double get length2 {
-    double sum;
-    sum = storage[0] * storage[0];
-    sum += storage[1] * storage[1];
-    return sum;
-  }
+  double get length2 => this[0] * this[0] + this[1] * this[1];
 
   /// Normalize this.
   double normalize() {
@@ -162,8 +154,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
+    this[0] *= d;
+    this[1] *= d;
     return l;
   }
 
@@ -196,8 +188,7 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other.storage;
-    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
+    if (this[0] == other[0] && this[1] == other[1]) {
       return 0.0;
     }
 
@@ -208,8 +199,7 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other.storage;
-    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
+    if (this[0] == other[0] && this[1] == other[1]) {
       return 0.0;
     }
 
@@ -220,39 +210,26 @@ class Vector2 implements Vector {
   }
 
   /// Inner product.
-  double dot(Vector2 other) {
-    final otherStorage = other.storage;
-    double sum;
-    sum = storage[0] * otherStorage[0];
-    sum += storage[1] * otherStorage[1];
-    return sum;
-  }
+  double dot(Vector2 other) => this[0] * other[0] + this[1] * other[1];
 
-  ///
   /// Transforms this into the product of this as a row vector,
   /// postmultiplied by matrix, [arg].
   /// If [arg] is a rotation matrix, this is a computational shortcut for
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    final argStorage = arg.storage;
-    final v0 = storage[0];
-    final v1 = storage[1];
-    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    this[0] = this[0] * arg[0] + this[1] * arg[1];
+    this[1] = this[0] * arg[2] + this[1] * arg[3];
   }
 
   /// Cross product.
-  double cross(Vector2 other) {
-    final otherStorage = other.storage;
-    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
-  }
+  double cross(Vector2 other) => this[0] * other[1] - this[1] * other[0];
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * storage[1], scale * storage[0]);
+    out.setValues(-scale * this[1], scale * this[0]);
     return out;
   }
 
@@ -265,70 +242,52 @@ class Vector2 implements Vector {
   Vector2 reflected(Vector2 normal) => clone()..reflect(normal);
 
   /// Relative error between this and [correct]
-  double relativeError(Vector2 correct) {
-    final correct_norm = correct.length;
-    final diff_norm = (this - correct).length;
-    return diff_norm / correct_norm;
-  }
+  double relativeError(Vector2 correct) =>
+      (this - correct).length / correct.length;
 
   /// Absolute error between this and [correct]
   double absoluteError(Vector2 correct) => (this - correct).length;
 
   /// True if any component is infinite.
-  bool get isInfinite {
-    var is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
-    return is_infinite;
-  }
+  bool get isInfinite => this[0].isInfinite || this[1].isInfinite;
 
   /// True if any component is NaN.
-  bool get isNaN {
-    var is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
-    return is_nan;
-  }
+  bool get isNaN => this[0].isNaN || this[1].isNaN;
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] + argStorage[0];
-    storage[1] = storage[1] + argStorage[1];
+    this[0] += arg[0];
+    this[1] += arg[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] + argStorage[0] * factor;
-    storage[1] = storage[1] + argStorage[1] * factor;
+    this[0] += arg[0] * factor;
+    this[1] += arg[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] - argStorage[0];
-    storage[1] = storage[1] - argStorage[1];
+    this[0] -= arg[0];
+    this[1] -= arg[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] * argStorage[0];
-    storage[1] = storage[1] * argStorage[1];
+    this[0] *= arg[0];
+    this[1] *= arg[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] / argStorage[0];
-    storage[1] = storage[1] / argStorage[1];
+    this[0] /= arg[0];
+    this[1] /= arg[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    storage[1] = storage[1] * arg;
-    storage[0] = storage[0] * arg;
+    this[0] *= arg;
+    this[1] *= arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -336,56 +295,50 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    storage[1] = -storage[1];
-    storage[0] = -storage[0];
+    this[0] *= -1;
+    this[1] *= -1;
   }
 
   /// Absolute value.
   void absolute() {
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    this[0] = this[0].abs();
+    this[1] = this[1].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
-    final minStorage = min.storage;
-    final maxStorage = max.storage;
-    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    this[0] = this[0].clamp(min[0], max[0]).toDouble();
+    this[1] = this[1].clamp(min[1], max[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    storage[0] = storage[0].clamp(min, max).toDouble();
-    storage[1] = storage[1].clamp(min, max).toDouble();
+    this[0] = this[0].clamp(min, max).toDouble();
+    this[1] = this[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    storage[0] = storage[0].floorToDouble();
-    storage[1] = storage[1].floorToDouble();
+    this[0] = this[0].floorToDouble();
+    this[1] = this[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    storage[0] = storage[0].ceilToDouble();
-    storage[1] = storage[1].ceilToDouble();
+    this[0] = this[0].ceilToDouble();
+    this[1] = this[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    storage[0] = storage[0].roundToDouble();
-    storage[1] = storage[1].roundToDouble();
+    this[0] = this[0].roundToDouble();
+    this[1] = this[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    storage[0] = storage[0] < 0.0
-        ? storage[0].ceilToDouble()
-        : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0
-        ? storage[1].ceilToDouble()
-        : storage[1].floorToDouble();
+    this[0] = this[0] < 0.0 ? this[0].ceilToDouble() : this[0].floorToDouble();
+    this[1] = this[1] < 0.0 ? this[1].ceilToDouble() : this[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -393,80 +346,77 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg.storage;
-    argStorage[1] = storage[1];
-    argStorage[0] = storage[0];
+    arg[0] = this[0];
+    arg[1] = this[1];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = storage[1];
-    array[offset + 0] = storage[0];
+    array[offset + 0] = this[0];
+    array[offset + 1] = this[1];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[1] = array[offset + 1];
-    storage[0] = array[offset + 0];
+    this[0] = array[offset + 0];
+    this[1] = array[offset + 1];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = argStorage[0];
-    storage[1] = argStorage[1];
+    this[0] = arg[0];
+    this[1] = arg[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[1] = argStorage[0];
-    storage[0] = argStorage[1];
+    this[0] = arg[1];
+    this[1] = arg[0];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
+  set x(double arg) => this[0] = arg;
+  set y(double arg) => this[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(storage[0], storage[0]);
-  Vector2 get xy => Vector2(storage[0], storage[1]);
-  Vector2 get yx => Vector2(storage[1], storage[0]);
-  Vector2 get yy => Vector2(storage[1], storage[1]);
-  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
+  Vector2 get xx => Vector2(this[0], this[0]);
+  Vector2 get xy => Vector2(this[0], this[1]);
+  Vector2 get yx => Vector2(this[1], this[0]);
+  Vector2 get yy => Vector2(this[1], this[1]);
+  Vector3 get xxx => Vector3(this[0], this[0], this[0]);
+  Vector3 get xxy => Vector3(this[0], this[0], this[1]);
+  Vector3 get xyx => Vector3(this[0], this[1], this[0]);
+  Vector3 get xyy => Vector3(this[0], this[1], this[1]);
+  Vector3 get yxx => Vector3(this[1], this[0], this[0]);
+  Vector3 get yxy => Vector3(this[1], this[0], this[1]);
+  Vector3 get yyx => Vector3(this[1], this[1], this[0]);
+  Vector3 get yyy => Vector3(this[1], this[1], this[1]);
+  Vector4 get xxxx => Vector4(this[0], this[0], this[0], this[0]);
+  Vector4 get xxxy => Vector4(this[0], this[0], this[0], this[1]);
+  Vector4 get xxyx => Vector4(this[0], this[0], this[1], this[0]);
+  Vector4 get xxyy => Vector4(this[0], this[0], this[1], this[1]);
+  Vector4 get xyxx => Vector4(this[0], this[1], this[0], this[0]);
+  Vector4 get xyxy => Vector4(this[0], this[1], this[0], this[1]);
+  Vector4 get xyyx => Vector4(this[0], this[1], this[1], this[0]);
+  Vector4 get xyyy => Vector4(this[0], this[1], this[1], this[1]);
+  Vector4 get yxxx => Vector4(this[1], this[0], this[0], this[0]);
+  Vector4 get yxxy => Vector4(this[1], this[0], this[0], this[1]);
+  Vector4 get yxyx => Vector4(this[1], this[0], this[1], this[0]);
+  Vector4 get yxyy => Vector4(this[1], this[0], this[1], this[1]);
+  Vector4 get yyxx => Vector4(this[1], this[1], this[0], this[0]);
+  Vector4 get yyxy => Vector4(this[1], this[1], this[0], this[1]);
+  Vector4 get yyyx => Vector4(this[1], this[1], this[1], this[0]);
+  Vector4 get yyyy => Vector4(this[1], this[1], this[1], this[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => storage[0];
-  double get y => storage[1];
+  double get x => this[0];
+  double get y => this[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -6,11 +6,9 @@ part of '../../vector_math.dart';
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float32List _v2storage;
-
   /// The components of the vector.
   @override
-  Float32List get storage => _v2storage;
+  final Float32List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -35,28 +33,31 @@ class Vector2 implements Vector {
   }
 
   /// Construct a new vector with the specified values.
-  factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
+  Vector2(double x, double y)
+      : storage = Float32List(2)
+          ..[0] = x
+          ..[1] = y;
 
   /// Initialized with values from [array] starting at [offset].
-  factory Vector2.array(List<double> array, [int offset = 0]) =>
-      Vector2.zero()..copyFromArray(array, offset);
+  Vector2.array(List<double> array, [int offset = 0])
+      : this(array[0 + offset], array[1 + offset]);
 
   /// Zero vector.
-  Vector2.zero() : _v2storage = Float32List(2);
+  Vector2.zero() : storage = Float32List(2);
 
   /// Splat [value] into all lanes of the vector.
-  factory Vector2.all(double value) => Vector2.zero()..splat(value);
+  Vector2.all(double value) : this(value, value);
 
   /// Copy of [other].
-  factory Vector2.copy(Vector2 other) => Vector2.zero()..setFrom(other);
+  Vector2.copy(Vector2 other) : this(other.x, other.y);
 
   /// Constructs Vector2 with a given [Float32List] as [storage].
-  Vector2.fromFloat32List(this._v2storage);
+  Vector2.fromFloat32List(this.storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
   /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : _v2storage = Float32List.view(buffer, offset, 2);
+      : storage = Float32List.view(buffer, offset, 2);
 
   /// Generate random vector in the range (0, 0) to (1, 1). You can
   /// optionally pass your own random number generator.
@@ -67,42 +68,42 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    _v2storage[0] = x_;
-    _v2storage[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    _v2storage[0] = 0.0;
-    _v2storage[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other._v2storage;
-    _v2storage[1] = otherStorage[1];
-    _v2storage[0] = otherStorage[0];
+    final otherStorage = other.storage;
+    storage[1] = otherStorage[1];
+    storage[0] = otherStorage[0];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    _v2storage[0] = arg;
-    _v2storage[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
       (other is Vector2) &&
-      (_v2storage[0] == other._v2storage[0]) &&
-      (_v2storage[1] == other._v2storage[1]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]);
 
   @override
-  int get hashCode => Object.hashAll(_v2storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();
@@ -120,11 +121,11 @@ class Vector2 implements Vector {
   Vector2 operator *(double scale) => clone()..scale(scale);
 
   /// Access the component of the vector at the index [i].
-  double operator [](int i) => _v2storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    _v2storage[i] = v;
+    storage[i] = v;
   }
 
   /// Set the length of the vector. A negative [value] will change the vectors
@@ -138,8 +139,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      _v2storage[0] *= l;
-      _v2storage[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -149,8 +150,8 @@ class Vector2 implements Vector {
   /// Length squared.
   double get length2 {
     double sum;
-    sum = _v2storage[0] * _v2storage[0];
-    sum += _v2storage[1] * _v2storage[1];
+    sum = storage[0] * storage[0];
+    sum += storage[1] * storage[1];
     return sum;
   }
 
@@ -161,8 +162,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    _v2storage[0] *= d;
-    _v2storage[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -195,8 +196,8 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -207,8 +208,8 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -220,10 +221,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
-    final otherStorage = other._v2storage;
+    final otherStorage = other.storage;
     double sum;
-    sum = _v2storage[0] * otherStorage[0];
-    sum += _v2storage[1] * otherStorage[1];
+    sum = storage[0] * otherStorage[0];
+    sum += storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -235,23 +236,23 @@ class Vector2 implements Vector {
   ///
   void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
-    final v0 = _v2storage[0];
-    final v1 = _v2storage[1];
-    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    final otherStorage = other._v2storage;
-    return _v2storage[0] * otherStorage[1] - _v2storage[1] * otherStorage[0];
+    final otherStorage = other.storage;
+    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
   }
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * _v2storage[1], scale * _v2storage[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -276,58 +277,58 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     var is_infinite = false;
-    is_infinite = is_infinite || _v2storage[0].isInfinite;
-    is_infinite = is_infinite || _v2storage[1].isInfinite;
+    is_infinite = is_infinite || storage[0].isInfinite;
+    is_infinite = is_infinite || storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     var is_nan = false;
-    is_nan = is_nan || _v2storage[0].isNaN;
-    is_nan = is_nan || _v2storage[1].isNaN;
+    is_nan = is_nan || storage[0].isNaN;
+    is_nan = is_nan || storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0];
-    _v2storage[1] = _v2storage[1] + argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0];
+    storage[1] = storage[1] + argStorage[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
-    _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0] * factor;
+    storage[1] = storage[1] + argStorage[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] - argStorage[0];
-    _v2storage[1] = _v2storage[1] - argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] - argStorage[0];
+    storage[1] = storage[1] - argStorage[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] * argStorage[0];
-    _v2storage[1] = _v2storage[1] * argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] * argStorage[0];
+    storage[1] = storage[1] * argStorage[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] / argStorage[0];
-    _v2storage[1] = _v2storage[1] / argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] / argStorage[0];
+    storage[1] = storage[1] / argStorage[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    _v2storage[1] = _v2storage[1] * arg;
-    _v2storage[0] = _v2storage[0] * arg;
+    storage[1] = storage[1] * arg;
+    storage[0] = storage[0] * arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -335,58 +336,56 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    _v2storage[1] = -_v2storage[1];
-    _v2storage[0] = -_v2storage[0];
+    storage[1] = -storage[1];
+    storage[0] = -storage[0];
   }
 
   /// Absolute value.
   void absolute() {
-    _v2storage[1] = _v2storage[1].abs();
-    _v2storage[0] = _v2storage[0].abs();
+    storage[1] = storage[1].abs();
+    storage[0] = storage[0].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
-    _v2storage[0] =
-        _v2storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    _v2storage[1] =
-        _v2storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
+    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    _v2storage[0] = _v2storage[0].clamp(min, max).toDouble();
-    _v2storage[1] = _v2storage[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    _v2storage[0] = _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    _v2storage[0] = _v2storage[0].ceilToDouble();
-    _v2storage[1] = _v2storage[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    _v2storage[0] = _v2storage[0].roundToDouble();
-    _v2storage[1] = _v2storage[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    _v2storage[0] = _v2storage[0] < 0.0
-        ? _v2storage[0].ceilToDouble()
-        : _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1] < 0.0
-        ? _v2storage[1].ceilToDouble()
-        : _v2storage[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -394,96 +393,80 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    argStorage[1] = _v2storage[1];
-    argStorage[0] = _v2storage[0];
+    final argStorage = arg.storage;
+    argStorage[1] = storage[1];
+    argStorage[0] = storage[0];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = _v2storage[1];
-    array[offset + 0] = _v2storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 0] = storage[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    _v2storage[1] = array[offset + 1];
-    _v2storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = argStorage[0];
-    _v2storage[1] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = argStorage[0];
+    storage[1] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[1] = argStorage[0];
-    _v2storage[0] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[1] = argStorage[0];
+    storage[0] = argStorage[1];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => _v2storage[0] = arg;
-  set y(double arg) => _v2storage[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(_v2storage[0], _v2storage[0]);
-  Vector2 get xy => Vector2(_v2storage[0], _v2storage[1]);
-  Vector2 get yx => Vector2(_v2storage[1], _v2storage[0]);
-  Vector2 get yy => Vector2(_v2storage[1], _v2storage[1]);
-  Vector3 get xxx => Vector3(_v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector3 get xxy => Vector3(_v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector3 get xyx => Vector3(_v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector3 get xyy => Vector3(_v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector3 get yxx => Vector3(_v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector3 get yxy => Vector3(_v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector3 get yyx => Vector3(_v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector3 get yyy => Vector3(_v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get xxxx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get xxxy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get xxyx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get xxyy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get xyxx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get xyxy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get xyyx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get xyyy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get yxxx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get yxxy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get yxyx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get yxyy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get yyxx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get yyxy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get yyyx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get yyyy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => _v2storage[0];
-  double get y => _v2storage[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -218,8 +218,10 @@ class Vector2 implements Vector {
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    this[0] = this[0] * arg[0] + this[1] * arg[1];
-    this[1] = this[0] * arg[2] + this[1] * arg[3];
+    final v0 = this[0];
+    final v1 = this[1];
+    this[0] = v0 * arg[0] + v1 * arg[1];
+    this[1] = v0 * arg[2] + v1 * arg[3];
   }
 
   /// Cross product.

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -555,37 +555,37 @@ class Vector3 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -461,73 +461,73 @@ class Vector4 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set xw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set yw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set zw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set wx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set wy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set wz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -88,8 +88,8 @@ class Matrix2 {
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector2 arg0, Vector2 arg1) {
-    final arg0Storage = arg0._v2storage;
-    final arg1Storage = arg1._v2storage;
+    final arg0Storage = arg0.storage;
+    final arg1Storage = arg1.storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
@@ -107,8 +107,8 @@ class Matrix2 {
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector2 u, Vector2 v) {
-    final uStorage = u._v2storage;
-    final vStorage = v._v2storage;
+    final uStorage = u.storage;
+    final vStorage = v.storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
@@ -123,7 +123,7 @@ class Matrix2 {
 
   /// Sets the diagonal of the matrix to be [arg].
   void setDiagonal(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
   }
@@ -169,7 +169,7 @@ class Matrix2 {
 
   /// Sets [row] of the matrix to values in [arg]
   void setRow(int row, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[index(row, 0)] = argStorage[0];
     _m2storage[index(row, 1)] = argStorage[1];
   }
@@ -177,7 +177,7 @@ class Matrix2 {
   /// Gets the [row] of the matrix
   Vector2 getRow(int row) {
     final r = Vector2.zero();
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[0] = _m2storage[index(row, 0)];
     rStorage[1] = _m2storage[index(row, 1)];
     return r;
@@ -185,7 +185,7 @@ class Matrix2 {
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final entry = column * 2;
     _m2storage[entry + 1] = argStorage[1];
     _m2storage[entry + 0] = argStorage[0];
@@ -195,7 +195,7 @@ class Matrix2 {
   Vector2 getColumn(int column) {
     final r = Vector2.zero();
     final entry = column * 2;
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[1] = _m2storage[entry + 1];
     rStorage[0] = _m2storage[entry + 0];
     return r;
@@ -279,13 +279,13 @@ class Matrix2 {
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[i] * vStorage[0] + _m2storage[2 + i] * vStorage[1];
   }
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[j * 2] * vStorage[0] +
         _m2storage[(j * 2) + 1] * vStorage[1];
   }
@@ -468,7 +468,7 @@ class Matrix2 {
   /// Transform [arg] of type [Vector2] using the transformation defined by
   /// this.
   Vector2 transform(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = (_m2storage[0] * argStorage[0]) + (_m2storage[2] * argStorage[1]);
     final y = (_m2storage[1] * argStorage[0]) + (_m2storage[3] * argStorage[1]);
     argStorage[0] = x;

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -633,7 +633,7 @@ class Matrix3 {
     final m01 = _m3storage[3].abs();
     final m10 = _m3storage[1].abs();
     final m11 = _m3storage[4].abs();
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = argStorage[0];
     final y = argStorage[1];
     argStorage[0] = x * m00 + y * m01;
@@ -643,7 +643,7 @@ class Matrix3 {
 
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x_ = (_m3storage[0] * argStorage[0]) +
         (_m3storage[3] * argStorage[1]) +
         _m3storage[6];

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -6,11 +6,9 @@ part of '../../vector_math_64.dart';
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float64List _v2storage;
-
   /// The components of the vector.
   @override
-  Float64List get storage => _v2storage;
+  final Float64List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -35,28 +33,31 @@ class Vector2 implements Vector {
   }
 
   /// Construct a new vector with the specified values.
-  factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
+  Vector2(double x, double y)
+      : storage = Float64List(2)
+          ..[0] = x
+          ..[1] = y;
 
   /// Initialized with values from [array] starting at [offset].
-  factory Vector2.array(List<double> array, [int offset = 0]) =>
-      Vector2.zero()..copyFromArray(array, offset);
+  Vector2.array(List<double> array, [int offset = 0])
+      : this(array[0 + offset], array[1 + offset]);
 
   /// Zero vector.
-  Vector2.zero() : _v2storage = Float64List(2);
+  Vector2.zero() : storage = Float64List(2);
 
   /// Splat [value] into all lanes of the vector.
-  factory Vector2.all(double value) => Vector2.zero()..splat(value);
+  Vector2.all(double value) : this(value, value);
 
   /// Copy of [other].
-  factory Vector2.copy(Vector2 other) => Vector2.zero()..setFrom(other);
+  Vector2.copy(Vector2 other) : this(other.x, other.y);
 
   /// Constructs Vector2 with a given [Float64List] as [storage].
-  Vector2.fromFloat64List(this._v2storage);
+  Vector2.fromFloat64List(this.storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
-  /// [offset]. [offset] has to be multiple of [Float64List.bytesPerElement].
+  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : _v2storage = Float64List.view(buffer, offset, 2);
+      : storage = Float64List.view(buffer, offset, 2);
 
   /// Generate random vector in the range (0, 0) to (1, 1). You can
   /// optionally pass your own random number generator.
@@ -67,42 +68,42 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    _v2storage[0] = x_;
-    _v2storage[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    _v2storage[0] = 0.0;
-    _v2storage[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other._v2storage;
-    _v2storage[1] = otherStorage[1];
-    _v2storage[0] = otherStorage[0];
+    final otherStorage = other.storage;
+    storage[1] = otherStorage[1];
+    storage[0] = otherStorage[0];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    _v2storage[0] = arg;
-    _v2storage[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
       (other is Vector2) &&
-      (_v2storage[0] == other._v2storage[0]) &&
-      (_v2storage[1] == other._v2storage[1]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]);
 
   @override
-  int get hashCode => Object.hashAll(_v2storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();
@@ -120,11 +121,11 @@ class Vector2 implements Vector {
   Vector2 operator *(double scale) => clone()..scale(scale);
 
   /// Access the component of the vector at the index [i].
-  double operator [](int i) => _v2storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    _v2storage[i] = v;
+    storage[i] = v;
   }
 
   /// Set the length of the vector. A negative [value] will change the vectors
@@ -138,8 +139,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      _v2storage[0] *= l;
-      _v2storage[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -149,8 +150,8 @@ class Vector2 implements Vector {
   /// Length squared.
   double get length2 {
     double sum;
-    sum = _v2storage[0] * _v2storage[0];
-    sum += _v2storage[1] * _v2storage[1];
+    sum = storage[0] * storage[0];
+    sum += storage[1] * storage[1];
     return sum;
   }
 
@@ -161,8 +162,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    _v2storage[0] *= d;
-    _v2storage[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -195,8 +196,8 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -207,8 +208,8 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -220,10 +221,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
-    final otherStorage = other._v2storage;
+    final otherStorage = other.storage;
     double sum;
-    sum = _v2storage[0] * otherStorage[0];
-    sum += _v2storage[1] * otherStorage[1];
+    sum = storage[0] * otherStorage[0];
+    sum += storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -235,23 +236,23 @@ class Vector2 implements Vector {
   ///
   void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
-    final v0 = _v2storage[0];
-    final v1 = _v2storage[1];
-    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    final otherStorage = other._v2storage;
-    return _v2storage[0] * otherStorage[1] - _v2storage[1] * otherStorage[0];
+    final otherStorage = other.storage;
+    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
   }
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * _v2storage[1], scale * _v2storage[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -276,58 +277,58 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     var is_infinite = false;
-    is_infinite = is_infinite || _v2storage[0].isInfinite;
-    is_infinite = is_infinite || _v2storage[1].isInfinite;
+    is_infinite = is_infinite || storage[0].isInfinite;
+    is_infinite = is_infinite || storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     var is_nan = false;
-    is_nan = is_nan || _v2storage[0].isNaN;
-    is_nan = is_nan || _v2storage[1].isNaN;
+    is_nan = is_nan || storage[0].isNaN;
+    is_nan = is_nan || storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0];
-    _v2storage[1] = _v2storage[1] + argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0];
+    storage[1] = storage[1] + argStorage[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
-    _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0] * factor;
+    storage[1] = storage[1] + argStorage[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] - argStorage[0];
-    _v2storage[1] = _v2storage[1] - argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] - argStorage[0];
+    storage[1] = storage[1] - argStorage[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] * argStorage[0];
-    _v2storage[1] = _v2storage[1] * argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] * argStorage[0];
+    storage[1] = storage[1] * argStorage[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] / argStorage[0];
-    _v2storage[1] = _v2storage[1] / argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] / argStorage[0];
+    storage[1] = storage[1] / argStorage[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    _v2storage[1] = _v2storage[1] * arg;
-    _v2storage[0] = _v2storage[0] * arg;
+    storage[1] = storage[1] * arg;
+    storage[0] = storage[0] * arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -335,58 +336,56 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    _v2storage[1] = -_v2storage[1];
-    _v2storage[0] = -_v2storage[0];
+    storage[1] = -storage[1];
+    storage[0] = -storage[0];
   }
 
   /// Absolute value.
   void absolute() {
-    _v2storage[1] = _v2storage[1].abs();
-    _v2storage[0] = _v2storage[0].abs();
+    storage[1] = storage[1].abs();
+    storage[0] = storage[0].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
-    _v2storage[0] =
-        _v2storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    _v2storage[1] =
-        _v2storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
+    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    _v2storage[0] = _v2storage[0].clamp(min, max).toDouble();
-    _v2storage[1] = _v2storage[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    _v2storage[0] = _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    _v2storage[0] = _v2storage[0].ceilToDouble();
-    _v2storage[1] = _v2storage[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    _v2storage[0] = _v2storage[0].roundToDouble();
-    _v2storage[1] = _v2storage[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    _v2storage[0] = _v2storage[0] < 0.0
-        ? _v2storage[0].ceilToDouble()
-        : _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1] < 0.0
-        ? _v2storage[1].ceilToDouble()
-        : _v2storage[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -394,96 +393,80 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    argStorage[1] = _v2storage[1];
-    argStorage[0] = _v2storage[0];
+    final argStorage = arg.storage;
+    argStorage[1] = storage[1];
+    argStorage[0] = storage[0];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = _v2storage[1];
-    array[offset + 0] = _v2storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 0] = storage[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    _v2storage[1] = array[offset + 1];
-    _v2storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = argStorage[0];
-    _v2storage[1] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = argStorage[0];
+    storage[1] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[1] = argStorage[0];
-    _v2storage[0] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[1] = argStorage[0];
+    storage[0] = argStorage[1];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => _v2storage[0] = arg;
-  set y(double arg) => _v2storage[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(_v2storage[0], _v2storage[0]);
-  Vector2 get xy => Vector2(_v2storage[0], _v2storage[1]);
-  Vector2 get yx => Vector2(_v2storage[1], _v2storage[0]);
-  Vector2 get yy => Vector2(_v2storage[1], _v2storage[1]);
-  Vector3 get xxx => Vector3(_v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector3 get xxy => Vector3(_v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector3 get xyx => Vector3(_v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector3 get xyy => Vector3(_v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector3 get yxx => Vector3(_v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector3 get yxy => Vector3(_v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector3 get yyx => Vector3(_v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector3 get yyy => Vector3(_v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get xxxx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get xxxy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get xxyx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get xxyy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get xyxx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get xyxy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get xyyx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get xyyy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get yxxx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get yxxy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get yxyx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get yxyy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get yyxx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get yyxy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get yyyx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get yyyy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => _v2storage[0];
-  double get y => _v2storage[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -555,37 +555,37 @@ class Vector3 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -461,73 +461,73 @@ class Vector4 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set xw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set yw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set zw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set wx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set wy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set wz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }


### PR DESCRIPTION
It is currently hard to extend `Vector2` and make use of its full potential due to the private field `_v2storage`, in this PR we use the `storage` field directly instead. This PR also refactors the factory constructors to be redirection constructors instead.

If this is accepted I can do this for the remaining classes too.

Closes #282 