### PR TITLE
Use `Matrix3.storage` directly instead of `_m3storage`

### DIFF
--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -88,8 +88,8 @@ class Matrix2 {
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector2 arg0, Vector2 arg1) {
-    final arg0Storage = arg0._v2storage;
-    final arg1Storage = arg1._v2storage;
+    final arg0Storage = arg0.storage;
+    final arg1Storage = arg1.storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
@@ -107,8 +107,8 @@ class Matrix2 {
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector2 u, Vector2 v) {
-    final uStorage = u._v2storage;
-    final vStorage = v._v2storage;
+    final uStorage = u.storage;
+    final vStorage = v.storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
@@ -123,7 +123,7 @@ class Matrix2 {
 
   /// Sets the diagonal of the matrix to be [arg].
   void setDiagonal(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
   }
@@ -169,7 +169,7 @@ class Matrix2 {
 
   /// Sets [row] of the matrix to values in [arg]
   void setRow(int row, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[index(row, 0)] = argStorage[0];
     _m2storage[index(row, 1)] = argStorage[1];
   }
@@ -177,7 +177,7 @@ class Matrix2 {
   /// Gets the [row] of the matrix
   Vector2 getRow(int row) {
     final r = Vector2.zero();
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[0] = _m2storage[index(row, 0)];
     rStorage[1] = _m2storage[index(row, 1)];
     return r;
@@ -185,7 +185,7 @@ class Matrix2 {
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final entry = column * 2;
     _m2storage[entry + 1] = argStorage[1];
     _m2storage[entry + 0] = argStorage[0];
@@ -195,7 +195,7 @@ class Matrix2 {
   Vector2 getColumn(int column) {
     final r = Vector2.zero();
     final entry = column * 2;
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[1] = _m2storage[entry + 1];
     rStorage[0] = _m2storage[entry + 0];
     return r;
@@ -279,13 +279,13 @@ class Matrix2 {
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[i] * vStorage[0] + _m2storage[2 + i] * vStorage[1];
   }
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[j * 2] * vStorage[0] +
         _m2storage[(j * 2) + 1] * vStorage[1];
   }
@@ -468,7 +468,7 @@ class Matrix2 {
   /// Transform [arg] of type [Vector2] using the transformation defined by
   /// this.
   Vector2 transform(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = (_m2storage[0] * argStorage[0]) + (_m2storage[2] * argStorage[1]);
     final y = (_m2storage[1] * argStorage[0]) + (_m2storage[3] * argStorage[1]);
     argStorage[0] = x;

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -108,7 +108,7 @@ class Matrix2 {
     this[3] = arg1[1];
   }
 
-  /// Sets the entire matrix to the matrix in [arg].
+  /// Sets the entire matrix to the matrix in [other].
   void setFrom(Matrix2 other) {
     this[3] = other[3];
     this[2] = other[2];
@@ -304,7 +304,7 @@ class Matrix2 {
     return det;
   }
 
-  /// Set this matrix to be the inverse of [arg]
+  /// Set this matrix to be the inverse of [other]
   double copyInverse(Matrix2 other) {
     final det = other.determinant();
     if (det == 0.0) {
@@ -389,10 +389,10 @@ class Matrix2 {
     this[3] = (m10 * n01) + (m11 * n11);
   }
 
-  /// Multiply this with [arg] and return the product.
+  /// Multiply this with [other] and return the product.
   Matrix2 multiplied(Matrix2 other) => clone()..multiply(other);
 
-  /// Multiply a transposed this with [arg].
+  /// Multiply a transposed this with [other].
   void transposeMultiply(Matrix2 other) {
     final m00 = this[0];
     final m01 = this[1];

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -7,10 +7,8 @@ part of '../../vector_math.dart';
 /// 2D Matrix.
 /// Values are stored in column major order.
 class Matrix2 {
-  final Float32List _m2storage;
-
   /// The components of the matrix.
-  Float32List get storage => _m2storage;
+  final Float32List storage;
 
   /// Solve [A] * [x] = [b].
   static void solve(Matrix2 A, Vector2 x, Vector2 b) {
@@ -31,6 +29,50 @@ class Matrix2 {
       ..y = det * (a11 * by - a21 * bx);
   }
 
+  /// New matrix with specified values.
+  Matrix2(double arg0, double arg1, double arg2, double arg3)
+      : storage = Float32List(4)
+          ..[0] = arg0
+          ..[1] = arg1
+          ..[2] = arg2
+          ..[3] = arg3;
+
+  /// New matrix from [values].
+  Matrix2.fromList(List<double> values)
+      : storage = Float32List.fromList(values);
+
+  /// Zero matrix.
+  Matrix2.zero() : storage = Float32List(4);
+
+  /// Identity matrix.
+  Matrix2.identity()
+      : storage = Float32List(4)
+          ..[0] = 1
+          ..[3] = 1;
+
+  /// Copies values from [other].
+  Matrix2.copy(Matrix2 other) : storage = Float32List.fromList(other.storage);
+
+  /// Matrix with values from column arguments.
+  Matrix2.columns(Vector2 arg0, Vector2 arg1)
+      : storage = Float32List(4)
+          ..[0] = arg0[0]
+          ..[1] = arg0[1]
+          ..[2] = arg1[0]
+          ..[3] = arg1[1];
+
+  /// Outer product of [u] and [v].
+  Matrix2.outer(Vector2 u, Vector2 v)
+      : storage = Float32List(4)
+          ..[0] = u[0] * v[0]
+          ..[1] = u[0] * v[1]
+          ..[2] = u[1] * v[0]
+          ..[3] = u[1] * v[1];
+
+  /// Rotation of [radians].
+  factory Matrix2.rotation(double radians) =>
+      Matrix2.zero()..setRotation(radians);
+
   /// Return index in storage for [row], [col] value.
   int index(int row, int col) => (col * 2) + row;
 
@@ -39,7 +81,7 @@ class Matrix2 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    return _m2storage[index(row, col)];
+    return this[index(row, col)];
   }
 
   /// Set value at [row], [col] to be [v].
@@ -47,85 +89,51 @@ class Matrix2 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    _m2storage[index(row, col)] = v;
+    this[index(row, col)] = v;
   }
-
-  /// New matrix with specified values.
-  factory Matrix2(double arg0, double arg1, double arg2, double arg3) =>
-      Matrix2.zero()..setValues(arg0, arg1, arg2, arg3);
-
-  /// New matrix from [values].
-  factory Matrix2.fromList(List<double> values) =>
-      Matrix2.zero()..setValues(values[0], values[1], values[2], values[3]);
-
-  /// Zero matrix.
-  Matrix2.zero() : _m2storage = Float32List(4);
-
-  /// Identity matrix.
-  factory Matrix2.identity() => Matrix2.zero()..setIdentity();
-
-  /// Copies values from [other].
-  factory Matrix2.copy(Matrix2 other) => Matrix2.zero()..setFrom(other);
-
-  /// Matrix with values from column arguments.
-  factory Matrix2.columns(Vector2 arg0, Vector2 arg1) =>
-      Matrix2.zero()..setColumns(arg0, arg1);
-
-  /// Outer product of [u] and [v].
-  factory Matrix2.outer(Vector2 u, Vector2 v) => Matrix2.zero()..setOuter(u, v);
-
-  /// Rotation of [radians].
-  factory Matrix2.rotation(double radians) =>
-      Matrix2.zero()..setRotation(radians);
 
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3) {
-    _m2storage[3] = arg3;
-    _m2storage[2] = arg2;
-    _m2storage[1] = arg1;
-    _m2storage[0] = arg0;
+    this[0] = arg0;
+    this[1] = arg1;
+    this[2] = arg2;
+    this[3] = arg3;
   }
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector2 arg0, Vector2 arg1) {
-    final arg0Storage = arg0.storage;
-    final arg1Storage = arg1.storage;
-    _m2storage[0] = arg0Storage[0];
-    _m2storage[1] = arg0Storage[1];
-    _m2storage[2] = arg1Storage[0];
-    _m2storage[3] = arg1Storage[1];
+    this[0] = arg0[0];
+    this[1] = arg0[1];
+    this[2] = arg1[0];
+    this[3] = arg1[1];
   }
 
   /// Sets the entire matrix to the matrix in [arg].
-  void setFrom(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    _m2storage[3] = argStorage[3];
-    _m2storage[2] = argStorage[2];
-    _m2storage[1] = argStorage[1];
-    _m2storage[0] = argStorage[0];
+  void setFrom(Matrix2 other) {
+    this[3] = other[3];
+    this[2] = other[2];
+    this[1] = other[1];
+    this[0] = other[0];
   }
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector2 u, Vector2 v) {
-    final uStorage = u.storage;
-    final vStorage = v.storage;
-    _m2storage[0] = uStorage[0] * vStorage[0];
-    _m2storage[1] = uStorage[0] * vStorage[1];
-    _m2storage[2] = uStorage[1] * vStorage[0];
-    _m2storage[3] = uStorage[1] * vStorage[1];
+    this[0] = u[0] * v[0];
+    this[1] = u[0] * v[1];
+    this[2] = u[1] * v[0];
+    this[3] = u[1] * v[1];
   }
 
   /// Sets the diagonal to [arg].
   void splatDiagonal(double arg) {
-    _m2storage[0] = arg;
-    _m2storage[3] = arg;
+    this[0] = arg;
+    this[3] = arg;
   }
 
   /// Sets the diagonal of the matrix to be [arg].
   void setDiagonal(Vector2 arg) {
-    final argStorage = arg.storage;
-    _m2storage[0] = argStorage[0];
-    _m2storage[3] = argStorage[1];
+    this[0] = arg[0];
+    this[3] = arg[1];
   }
 
   /// Returns a printable string
@@ -136,24 +144,24 @@ class Matrix2 {
   int get dimension => 2;
 
   /// Access the element of the matrix at the index [i].
-  double operator [](int i) => _m2storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
-    _m2storage[i] = v;
+    storage[i] = v;
   }
 
   /// Check if two matrices are the same.
   @override
   bool operator ==(Object other) =>
       (other is Matrix2) &&
-      (_m2storage[0] == other._m2storage[0]) &&
-      (_m2storage[1] == other._m2storage[1]) &&
-      (_m2storage[2] == other._m2storage[2]) &&
-      (_m2storage[3] == other._m2storage[3]);
+      (this[0] == other[0]) &&
+      (this[1] == other[1]) &&
+      (this[2] == other[2]) &&
+      (this[3] == other[3]);
 
   @override
-  int get hashCode => Object.hashAll(_m2storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Returns row 0
   Vector2 get row0 => getRow(0);
@@ -169,168 +177,117 @@ class Matrix2 {
 
   /// Sets [row] of the matrix to values in [arg]
   void setRow(int row, Vector2 arg) {
-    final argStorage = arg.storage;
-    _m2storage[index(row, 0)] = argStorage[0];
-    _m2storage[index(row, 1)] = argStorage[1];
+    this[index(row, 0)] = arg[0];
+    this[index(row, 1)] = arg[1];
   }
 
   /// Gets the [row] of the matrix
-  Vector2 getRow(int row) {
-    final r = Vector2.zero();
-    final rStorage = r.storage;
-    rStorage[0] = _m2storage[index(row, 0)];
-    rStorage[1] = _m2storage[index(row, 1)];
-    return r;
-  }
+  Vector2 getRow(int row) => Vector2(this[index(row, 0)], this[index(row, 1)]);
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector2 arg) {
-    final argStorage = arg.storage;
     final entry = column * 2;
-    _m2storage[entry + 1] = argStorage[1];
-    _m2storage[entry + 0] = argStorage[0];
+    this[entry + 1] = arg[1];
+    this[entry + 0] = arg[0];
   }
 
   /// Gets the [column] of the matrix
   Vector2 getColumn(int column) {
-    final r = Vector2.zero();
     final entry = column * 2;
-    final rStorage = r.storage;
-    rStorage[1] = _m2storage[entry + 1];
-    rStorage[0] = _m2storage[entry + 0];
-    return r;
+    return Vector2(this[entry + 0], this[entry + 1]);
   }
 
   /// Create a copy of this.
   Matrix2 clone() => Matrix2.copy(this);
 
-  /// Copy this into [arg].
-  Matrix2 copyInto(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    argStorage[0] = _m2storage[0];
-    argStorage[1] = _m2storage[1];
-    argStorage[2] = _m2storage[2];
-    argStorage[3] = _m2storage[3];
-    return arg;
+  /// Copy this into [other].
+  Matrix2 copyInto(Matrix2 other) => other..setFrom(this);
+
+  /// Returns a new vector or matrix by multiplying this with [other].
+  dynamic operator *(dynamic other) {
+    if (other is double) {
+      return scaled(other);
+    }
+    if (other is Vector2) {
+      return transformed(other);
+    }
+    if (other is Matrix2) {
+      return multiplied(other);
+    }
+    throw ArgumentError(other);
   }
 
-  /// Returns a new vector or matrix by multiplying this with [arg].
-  dynamic operator *(dynamic arg) {
-    if (arg is double) {
-      return scaled(arg);
-    }
-    if (arg is Vector2) {
-      return transformed(arg);
-    }
-    if (arg is Matrix2) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
-  }
+  /// Returns new matrix after component wise this + [other]
+  Matrix2 operator +(Matrix2 other) => clone()..add(other);
 
-  /// Returns new matrix after component wise this + [arg]
-  Matrix2 operator +(Matrix2 arg) => clone()..add(arg);
-
-  /// Returns new matrix after component wise this - [arg]
-  Matrix2 operator -(Matrix2 arg) => clone()..sub(arg);
+  /// Returns new matrix after component wise this - [other]
+  Matrix2 operator -(Matrix2 other) => clone()..sub(other);
 
   /// Returns new matrix -this
   Matrix2 operator -() => clone()..negate();
 
   /// Zeros this.
   void setZero() {
-    _m2storage[0] = 0.0;
-    _m2storage[1] = 0.0;
-    _m2storage[2] = 0.0;
-    _m2storage[3] = 0.0;
+    this[0] = 0.0;
+    this[1] = 0.0;
+    this[2] = 0.0;
+    this[3] = 0.0;
   }
 
   /// Makes this into the identity matrix.
   void setIdentity() {
-    _m2storage[0] = 1.0;
-    _m2storage[1] = 0.0;
-    _m2storage[2] = 0.0;
-    _m2storage[3] = 1.0;
+    this[0] = 1.0;
+    this[1] = 0.0;
+    this[2] = 0.0;
+    this[3] = 1.0;
   }
 
   /// Returns the tranpose of this.
   Matrix2 transposed() => clone()..transpose();
 
   void transpose() {
-    final temp = _m2storage[2];
-    _m2storage[2] = _m2storage[1];
-    _m2storage[1] = temp;
+    final temp = this[2];
+    this[2] = this[1];
+    this[1] = temp;
   }
 
   /// Returns the component wise absolute value of this.
-  Matrix2 absolute() {
-    final r = Matrix2.zero();
-    final rStorage = r._m2storage;
-    rStorage[0] = _m2storage[0].abs();
-    rStorage[1] = _m2storage[1].abs();
-    rStorage[2] = _m2storage[2].abs();
-    rStorage[3] = _m2storage[3].abs();
-    return r;
-  }
+  Matrix2 absolute() =>
+      Matrix2(this[0].abs(), this[1].abs(), this[3].abs(), this[3].abs());
 
   /// Returns the determinant of this matrix.
-  double determinant() =>
-      (_m2storage[0] * _m2storage[3]) - (_m2storage[1] * _m2storage[2]);
+  double determinant() => (this[0] * this[3]) - (this[1] * this[2]);
 
   /// Returns the dot product of row [i] and [v].
-  double dotRow(int i, Vector2 v) {
-    final vStorage = v.storage;
-    return _m2storage[i] * vStorage[0] + _m2storage[2 + i] * vStorage[1];
-  }
+  double dotRow(int i, Vector2 v) => this[i] * v[0] + this[2 + i] * v[1];
 
   /// Returns the dot product of column [j] and [v].
-  double dotColumn(int j, Vector2 v) {
-    final vStorage = v.storage;
-    return _m2storage[j * 2] * vStorage[0] +
-        _m2storage[(j * 2) + 1] * vStorage[1];
-  }
+  double dotColumn(int j, Vector2 v) =>
+      this[j * 2] * v[0] + this[(j * 2) + 1] * v[1];
 
   /// Trace of the matrix.
-  double trace() {
-    var t = 0.0;
-    t += _m2storage[0];
-    t += _m2storage[3];
-    return t;
-  }
+  double trace() => this[0] + this[3];
 
   /// Returns infinity norm of the matrix. Used for numerical analysis.
   double infinityNorm() {
-    var norm = 0.0;
-    {
-      var rowNorm = 0.0;
-      rowNorm += _m2storage[0].abs();
-      rowNorm += _m2storage[1].abs();
-      norm = rowNorm > norm ? rowNorm : norm;
-    }
-    {
-      var rowNorm = 0.0;
-      rowNorm += _m2storage[2].abs();
-      rowNorm += _m2storage[3].abs();
-      norm = rowNorm > norm ? rowNorm : norm;
-    }
-    return norm;
+    final result = math.max(
+      this[0].abs() + this[1].abs(),
+      this[2].abs() + this[3].abs(),
+    );
+    return result > 0 ? result : 0;
   }
 
   /// Returns relative error between this and [correct]
   double relativeError(Matrix2 correct) {
     final diff = correct - this;
     final correctNorm = correct.infinityNorm();
-    final diff_norm = diff.infinityNorm();
-    return diff_norm / correctNorm;
+    final diffNorm = diff.infinityNorm();
+    return diffNorm / correctNorm;
   }
 
   /// Returns absolute error between this and [correct]
-  double absoluteError(Matrix2 correct) {
-    final this_norm = infinityNorm();
-    final correct_norm = correct.infinityNorm();
-    final diff_norm = (this_norm - correct_norm).abs();
-    return diff_norm;
-  }
+  double absoluteError(Matrix2 correct) =>
+      (infinityNorm() - correct.infinityNorm()).abs();
 
   /// Invert the matrix. Returns the determinant.
   double invert() {
@@ -339,27 +296,26 @@ class Matrix2 {
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final temp = _m2storage[0];
-    _m2storage[0] = _m2storage[3] * invDet;
-    _m2storage[1] = -_m2storage[1] * invDet;
-    _m2storage[2] = -_m2storage[2] * invDet;
-    _m2storage[3] = temp * invDet;
+    final temp = this[0];
+    this[0] = this[3] * invDet;
+    this[1] = -this[1] * invDet;
+    this[2] = -this[2] * invDet;
+    this[3] = temp * invDet;
     return det;
   }
 
   /// Set this matrix to be the inverse of [arg]
-  double copyInverse(Matrix2 arg) {
-    final det = arg.determinant();
+  double copyInverse(Matrix2 other) {
+    final det = other.determinant();
     if (det == 0.0) {
-      setFrom(arg);
+      setFrom(other);
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final argStorage = arg._m2storage;
-    _m2storage[0] = argStorage[3] * invDet;
-    _m2storage[1] = -argStorage[1] * invDet;
-    _m2storage[2] = -argStorage[2] * invDet;
-    _m2storage[3] = argStorage[0] * invDet;
+    this[0] = other[3] * invDet;
+    this[1] = -other[1] * invDet;
+    this[2] = -other[2] * invDet;
+    this[3] = other[0] * invDet;
     return det;
   }
 
@@ -367,142 +323,128 @@ class Matrix2 {
   void setRotation(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m2storage[0] = c;
-    _m2storage[1] = s;
-    _m2storage[2] = -s;
-    _m2storage[3] = c;
+    this[0] = c;
+    this[1] = s;
+    this[2] = -s;
+    this[3] = c;
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
   void scaleAdjoint(double scale) {
-    final temp = _m2storage[0];
-    _m2storage[0] = _m2storage[3] * scale;
-    _m2storage[2] = -_m2storage[2] * scale;
-    _m2storage[1] = -_m2storage[1] * scale;
-    _m2storage[3] = temp * scale;
+    final temp = this[0];
+    this[0] = this[3] * scale;
+    this[2] = -this[2] * scale;
+    this[1] = -this[1] * scale;
+    this[3] = temp * scale;
   }
 
   /// Scale this by [scale].
   void scale(double scale) {
-    _m2storage[0] = _m2storage[0] * scale;
-    _m2storage[1] = _m2storage[1] * scale;
-    _m2storage[2] = _m2storage[2] * scale;
-    _m2storage[3] = _m2storage[3] * scale;
+    this[0] *= scale;
+    this[1] *= scale;
+    this[2] *= scale;
+    this[3] *= scale;
   }
 
   /// Create a copy of this scaled by [scale].
   Matrix2 scaled(double scale) => clone()..scale(scale);
 
-  /// Add [o] to this.
-  void add(Matrix2 o) {
-    final oStorage = o._m2storage;
-    _m2storage[0] = _m2storage[0] + oStorage[0];
-    _m2storage[1] = _m2storage[1] + oStorage[1];
-    _m2storage[2] = _m2storage[2] + oStorage[2];
-    _m2storage[3] = _m2storage[3] + oStorage[3];
+  /// Add [other] to this.
+  void add(Matrix2 other) {
+    this[0] += other[0];
+    this[1] += other[1];
+    this[2] += other[2];
+    this[3] += other[3];
   }
 
-  /// Subtract [o] from this.
-  void sub(Matrix2 o) {
-    final oStorage = o._m2storage;
-    _m2storage[0] = _m2storage[0] - oStorage[0];
-    _m2storage[1] = _m2storage[1] - oStorage[1];
-    _m2storage[2] = _m2storage[2] - oStorage[2];
-    _m2storage[3] = _m2storage[3] - oStorage[3];
+  /// Subtract [other] from this.
+  void sub(Matrix2 other) {
+    this[0] -= other[0];
+    this[1] -= other[1];
+    this[2] -= other[2];
+    this[3] -= other[3];
   }
 
   /// Negate this.
   void negate() {
-    _m2storage[0] = -_m2storage[0];
-    _m2storage[1] = -_m2storage[1];
-    _m2storage[2] = -_m2storage[2];
-    _m2storage[3] = -_m2storage[3];
+    this[0] *= -1;
+    this[1] *= -1;
+    this[2] *= -1;
+    this[3] *= -1;
   }
 
-  /// Multiply this with [arg] and store it in this.
-  void multiply(Matrix2 arg) {
-    final m00 = _m2storage[0];
-    final m01 = _m2storage[2];
-    final m10 = _m2storage[1];
-    final m11 = _m2storage[3];
-    final argStorage = arg._m2storage;
-    final n00 = argStorage[0];
-    final n01 = argStorage[2];
-    final n10 = argStorage[1];
-    final n11 = argStorage[3];
-    _m2storage[0] = (m00 * n00) + (m01 * n10);
-    _m2storage[2] = (m00 * n01) + (m01 * n11);
-    _m2storage[1] = (m10 * n00) + (m11 * n10);
-    _m2storage[3] = (m10 * n01) + (m11 * n11);
+  /// Multiply this with [other] and store it in this.
+  void multiply(Matrix2 other) {
+    final m00 = this[0];
+    final m01 = this[2];
+    final m10 = this[1];
+    final m11 = this[3];
+    final n00 = other[0];
+    final n01 = other[2];
+    final n10 = other[1];
+    final n11 = other[3];
+    this[0] = (m00 * n00) + (m01 * n10);
+    this[2] = (m00 * n01) + (m01 * n11);
+    this[1] = (m10 * n00) + (m11 * n10);
+    this[3] = (m10 * n01) + (m11 * n11);
   }
 
   /// Multiply this with [arg] and return the product.
-  Matrix2 multiplied(Matrix2 arg) => clone()..multiply(arg);
+  Matrix2 multiplied(Matrix2 other) => clone()..multiply(other);
 
   /// Multiply a transposed this with [arg].
-  void transposeMultiply(Matrix2 arg) {
-    final m00 = _m2storage[0];
-    final m01 = _m2storage[1];
-    final m10 = _m2storage[2];
-    final m11 = _m2storage[3];
-    final argStorage = arg._m2storage;
-    _m2storage[0] = (m00 * argStorage[0]) + (m01 * argStorage[1]);
-    _m2storage[2] = (m00 * argStorage[2]) + (m01 * argStorage[3]);
-    _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[1]);
-    _m2storage[3] = (m10 * argStorage[2]) + (m11 * argStorage[3]);
+  void transposeMultiply(Matrix2 other) {
+    final m00 = this[0];
+    final m01 = this[1];
+    final m10 = this[2];
+    final m11 = this[3];
+    this[0] = (m00 * other[0]) + (m01 * other[1]);
+    this[2] = (m00 * other[2]) + (m01 * other[3]);
+    this[1] = (m10 * other[0]) + (m11 * other[1]);
+    this[3] = (m10 * other[2]) + (m11 * other[3]);
   }
 
-  /// Multiply this with a transposed [arg].
-  void multiplyTranspose(Matrix2 arg) {
-    final m00 = _m2storage[0];
-    final m01 = _m2storage[2];
-    final m10 = _m2storage[1];
-    final m11 = _m2storage[3];
-    final argStorage = arg._m2storage;
-    _m2storage[0] = (m00 * argStorage[0]) + (m01 * argStorage[2]);
-    _m2storage[2] = (m00 * argStorage[1]) + (m01 * argStorage[3]);
-    _m2storage[1] = (m10 * argStorage[0]) + (m11 * argStorage[2]);
-    _m2storage[3] = (m10 * argStorage[1]) + (m11 * argStorage[3]);
+  /// Multiply this with a transposed [other].
+  void multiplyTranspose(Matrix2 other) {
+    final m00 = this[0];
+    final m01 = this[2];
+    final m10 = this[1];
+    final m11 = this[3];
+    this[0] = (m00 * other[0]) + (m01 * other[2]);
+    this[2] = (m00 * other[1]) + (m01 * other[3]);
+    this[1] = (m10 * other[0]) + (m11 * other[2]);
+    this[3] = (m10 * other[1]) + (m11 * other[3]);
   }
 
   /// Transform [arg] of type [Vector2] using the transformation defined by
   /// this.
   Vector2 transform(Vector2 arg) {
-    final argStorage = arg.storage;
-    final x = (_m2storage[0] * argStorage[0]) + (_m2storage[2] * argStorage[1]);
-    final y = (_m2storage[1] * argStorage[0]) + (_m2storage[3] * argStorage[1]);
-    argStorage[0] = x;
-    argStorage[1] = y;
-    return arg;
+    final x = (this[0] * arg[0]) + (this[2] * arg[1]);
+    final y = (this[1] * arg[0]) + (this[3] * arg[1]);
+    return arg..setValues(x, y);
   }
 
   /// Transform a copy of [arg] of type [Vector2] using the transformation
   /// defined by this. If a [out] parameter is supplied, the copy is stored in
   /// [out].
   Vector2 transformed(Vector2 arg, [Vector2? out]) {
-    if (out == null) {
-      out = Vector2.copy(arg);
-    } else {
-      out.setFrom(arg);
-    }
-    return transform(out);
+    final outLocal = (out?..setFrom(arg)) ?? arg.clone();
+    return transform(outLocal);
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<num> array, [int offset = 0]) {
-    final i = offset;
-    array[i + 3] = _m2storage[3];
-    array[i + 2] = _m2storage[2];
-    array[i + 1] = _m2storage[1];
-    array[i + 0] = _m2storage[0];
+    array[offset + 3] = this[3];
+    array[offset + 2] = this[2];
+    array[offset + 1] = this[1];
+    array[offset + 0] = this[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    final i = offset;
-    _m2storage[3] = array[i + 3];
-    _m2storage[2] = array[i + 2];
-    _m2storage[1] = array[i + 1];
-    _m2storage[0] = array[i + 0];
+    this[0] = array[offset + 0];
+    this[1] = array[offset + 1];
+    this[2] = array[offset + 2];
+    this[3] = array[offset + 3];
   }
 }

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -7,10 +7,8 @@ part of '../../vector_math.dart';
 /// 3D Matrix.
 /// Values are stored in column major order.
 class Matrix3 {
-  final Float32List _m3storage;
-
   /// The components of the matrix.
-  Float32List get storage => _m3storage;
+  final Float32List storage;
 
   /// Solve [A] * [x] = [b].
   static void solve2(Matrix3 A, Vector2 x, Vector2 b) {
@@ -79,51 +77,70 @@ class Matrix3 {
       ..z = z_;
   }
 
-  /// Return index in storage for [row], [col] value.
-  int index(int row, int col) => (col * 3) + row;
-
-  /// Value at [row], [col].
-  double entry(int row, int col) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    return _m3storage[index(row, col)];
-  }
-
-  /// Set value at [row], [col] to be [v].
-  void setEntry(int row, int col, double v) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    _m3storage[index(row, col)] = v;
-  }
-
   /// New matrix with specified values.
-  factory Matrix3(double arg0, double arg1, double arg2, double arg3,
-          double arg4, double arg5, double arg6, double arg7, double arg8) =>
-      Matrix3.zero()
-        ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+  Matrix3(
+    double arg0,
+    double arg1,
+    double arg2,
+    double arg3,
+    double arg4,
+    double arg5,
+    double arg6,
+    double arg7,
+    double arg8,
+  ) : storage = Float32List(9)
+          ..[0] = arg0
+          ..[1] = arg1
+          ..[2] = arg2
+          ..[3] = arg3
+          ..[4] = arg4
+          ..[5] = arg5
+          ..[6] = arg6
+          ..[7] = arg7
+          ..[8] = arg8;
 
   /// New matrix from [values].
-  factory Matrix3.fromList(List<double> values) => Matrix3.zero()
-    ..setValues(values[0], values[1], values[2], values[3], values[4],
-        values[5], values[6], values[7], values[8]);
+  Matrix3.fromList(List<double> values)
+      : storage = Float32List.fromList(values);
 
   /// Constructs a new [Matrix3] filled with zeros.
-  Matrix3.zero() : _m3storage = Float32List(9);
+  Matrix3.zero() : storage = Float32List(9);
 
   /// Identity matrix.
-  factory Matrix3.identity() => Matrix3.zero()..setIdentity();
+  Matrix3.identity()
+      : storage = Float32List(9)
+          ..[0] = 1.0
+          ..[4] = 1.0
+          ..[8] = 1.0;
 
   /// Copes values from [other].
-  factory Matrix3.copy(Matrix3 other) => Matrix3.zero()..setFrom(other);
+  Matrix3.copy(Matrix3 other) : storage = Float32List.fromList(other.storage);
 
-  /// Constructs a new mat3 from columns.
-  factory Matrix3.columns(Vector3 arg0, Vector3 arg1, Vector3 arg2) =>
-      Matrix3.zero()..setColumns(arg0, arg1, arg2);
+  /// Constructs a new [Matrix3]from columns.
+  Matrix3.columns(Vector3 arg0, Vector3 arg1, Vector3 arg2)
+      : storage = Float32List(9)
+          ..[0] = arg0[0]
+          ..[1] = arg0[1]
+          ..[2] = arg0[2]
+          ..[3] = arg1[0]
+          ..[4] = arg1[1]
+          ..[5] = arg1[2]
+          ..[6] = arg2[0]
+          ..[7] = arg2[1]
+          ..[8] = arg2[2];
 
   /// Outer product of [u] and [v].
-  factory Matrix3.outer(Vector3 u, Vector3 v) => Matrix3.zero()..setOuter(u, v);
+  Matrix3.outer(Vector3 u, Vector3 v)
+      : storage = Float32List(9)
+          ..[0] = u[0] * v[0]
+          ..[1] = u[0] * v[1]
+          ..[2] = u[0] * v[2]
+          ..[3] = u[1] * v[0]
+          ..[4] = u[1] * v[1]
+          ..[5] = u[1] * v[2]
+          ..[6] = u[2] * v[0]
+          ..[7] = u[2] * v[1]
+          ..[8] = u[2] * v[2];
 
   /// Rotation of [radians] around X axis.
   factory Matrix3.rotationX(double radians) =>
@@ -137,18 +154,37 @@ class Matrix3 {
   factory Matrix3.rotationZ(double radians) =>
       Matrix3.zero()..setRotationZ(radians);
 
+  /// Return index in storage for [row], [col] value.
+  int index(int row, int col) => (col * 3) + row;
+
+  /// Value at [row], [col].
+  double entry(int row, int col) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    return storage[index(row, col)];
+  }
+
+  /// Set value at [row], [col] to be [v].
+  void setEntry(int row, int col, double v) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    storage[index(row, col)] = v;
+  }
+
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
-    _m3storage[8] = arg8;
-    _m3storage[7] = arg7;
-    _m3storage[6] = arg6;
-    _m3storage[5] = arg5;
-    _m3storage[4] = arg4;
-    _m3storage[3] = arg3;
-    _m3storage[2] = arg2;
-    _m3storage[1] = arg1;
-    _m3storage[0] = arg0;
+    storage[8] = arg8;
+    storage[7] = arg7;
+    storage[6] = arg6;
+    storage[5] = arg5;
+    storage[4] = arg4;
+    storage[3] = arg3;
+    storage[2] = arg2;
+    storage[1] = arg1;
+    storage[0] = arg0;
   }
 
   /// Sets the entire matrix to the column values.
@@ -156,66 +192,66 @@ class Matrix3 {
     final arg0Storage = arg0._v3storage;
     final arg1Storage = arg1._v3storage;
     final arg2Storage = arg2._v3storage;
-    _m3storage[0] = arg0Storage[0];
-    _m3storage[1] = arg0Storage[1];
-    _m3storage[2] = arg0Storage[2];
-    _m3storage[3] = arg1Storage[0];
-    _m3storage[4] = arg1Storage[1];
-    _m3storage[5] = arg1Storage[2];
-    _m3storage[6] = arg2Storage[0];
-    _m3storage[7] = arg2Storage[1];
-    _m3storage[8] = arg2Storage[2];
+    storage[0] = arg0Storage[0];
+    storage[1] = arg0Storage[1];
+    storage[2] = arg0Storage[2];
+    storage[3] = arg1Storage[0];
+    storage[4] = arg1Storage[1];
+    storage[5] = arg1Storage[2];
+    storage[6] = arg2Storage[0];
+    storage[7] = arg2Storage[1];
+    storage[8] = arg2Storage[2];
   }
 
   /// Sets the entire matrix to the matrix in [arg].
   void setFrom(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    _m3storage[8] = argStorage[8];
-    _m3storage[7] = argStorage[7];
-    _m3storage[6] = argStorage[6];
-    _m3storage[5] = argStorage[5];
-    _m3storage[4] = argStorage[4];
-    _m3storage[3] = argStorage[3];
-    _m3storage[2] = argStorage[2];
-    _m3storage[1] = argStorage[1];
-    _m3storage[0] = argStorage[0];
+    final argStorage = arg.storage;
+    storage[8] = argStorage[8];
+    storage[7] = argStorage[7];
+    storage[6] = argStorage[6];
+    storage[5] = argStorage[5];
+    storage[4] = argStorage[4];
+    storage[3] = argStorage[3];
+    storage[2] = argStorage[2];
+    storage[1] = argStorage[1];
+    storage[0] = argStorage[0];
   }
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector3 u, Vector3 v) {
     final uStorage = u._v3storage;
     final vStorage = v._v3storage;
-    _m3storage[0] = uStorage[0] * vStorage[0];
-    _m3storage[1] = uStorage[0] * vStorage[1];
-    _m3storage[2] = uStorage[0] * vStorage[2];
-    _m3storage[3] = uStorage[1] * vStorage[0];
-    _m3storage[4] = uStorage[1] * vStorage[1];
-    _m3storage[5] = uStorage[1] * vStorage[2];
-    _m3storage[6] = uStorage[2] * vStorage[0];
-    _m3storage[7] = uStorage[2] * vStorage[1];
-    _m3storage[8] = uStorage[2] * vStorage[2];
+    storage[0] = uStorage[0] * vStorage[0];
+    storage[1] = uStorage[0] * vStorage[1];
+    storage[2] = uStorage[0] * vStorage[2];
+    storage[3] = uStorage[1] * vStorage[0];
+    storage[4] = uStorage[1] * vStorage[1];
+    storage[5] = uStorage[1] * vStorage[2];
+    storage[6] = uStorage[2] * vStorage[0];
+    storage[7] = uStorage[2] * vStorage[1];
+    storage[8] = uStorage[2] * vStorage[2];
   }
 
   /// Set the diagonal of the matrix.
   void splatDiagonal(double arg) {
-    _m3storage[0] = arg;
-    _m3storage[4] = arg;
-    _m3storage[8] = arg;
+    storage[0] = arg;
+    storage[4] = arg;
+    storage[8] = arg;
   }
 
   /// Set the diagonal of the matrix.
   void setDiagonal(Vector3 arg) {
-    _m3storage[0] = arg.storage[0];
-    _m3storage[4] = arg.storage[1];
-    _m3storage[8] = arg.storage[2];
+    storage[0] = arg.storage[0];
+    storage[4] = arg.storage[1];
+    storage[8] = arg.storage[2];
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    _m3storage[0] = arg[0];
-    _m3storage[1] = arg[1];
-    _m3storage[3] = arg[2];
-    _m3storage[4] = arg[3];
+    storage[0] = arg[0];
+    storage[1] = arg[1];
+    storage[3] = arg[2];
+    storage[4] = arg[3];
   }
 
   /// Returns a printable string
@@ -226,29 +262,29 @@ class Matrix3 {
   int get dimension => 3;
 
   /// Access the element of the matrix at the index [i].
-  double operator [](int i) => _m3storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
-    _m3storage[i] = v;
+    storage[i] = v;
   }
 
   /// Check if two matrices are the same.
   @override
   bool operator ==(Object other) =>
       (other is Matrix3) &&
-      (_m3storage[0] == other._m3storage[0]) &&
-      (_m3storage[1] == other._m3storage[1]) &&
-      (_m3storage[2] == other._m3storage[2]) &&
-      (_m3storage[3] == other._m3storage[3]) &&
-      (_m3storage[4] == other._m3storage[4]) &&
-      (_m3storage[5] == other._m3storage[5]) &&
-      (_m3storage[6] == other._m3storage[6]) &&
-      (_m3storage[7] == other._m3storage[7]) &&
-      (_m3storage[8] == other._m3storage[8]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]) &&
+      (storage[2] == other.storage[2]) &&
+      (storage[3] == other.storage[3]) &&
+      (storage[4] == other.storage[4]) &&
+      (storage[5] == other.storage[5]) &&
+      (storage[6] == other.storage[6]) &&
+      (storage[7] == other.storage[7]) &&
+      (storage[8] == other.storage[8]);
 
   @override
-  int get hashCode => Object.hashAll(_m3storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Returns row 0
   Vector3 get row0 => getRow(0);
@@ -271,18 +307,18 @@ class Matrix3 {
   /// Assigns the [row] of to [arg].
   void setRow(int row, Vector3 arg) {
     final argStorage = arg._v3storage;
-    _m3storage[index(row, 0)] = argStorage[0];
-    _m3storage[index(row, 1)] = argStorage[1];
-    _m3storage[index(row, 2)] = argStorage[2];
+    storage[index(row, 0)] = argStorage[0];
+    storage[index(row, 1)] = argStorage[1];
+    storage[index(row, 2)] = argStorage[2];
   }
 
   /// Gets the [row] of the matrix
   Vector3 getRow(int row) {
     final r = Vector3.zero();
     final rStorage = r._v3storage;
-    rStorage[0] = _m3storage[index(row, 0)];
-    rStorage[1] = _m3storage[index(row, 1)];
-    rStorage[2] = _m3storage[index(row, 2)];
+    rStorage[0] = storage[index(row, 0)];
+    rStorage[1] = storage[index(row, 1)];
+    rStorage[2] = storage[index(row, 2)];
     return r;
   }
 
@@ -290,9 +326,9 @@ class Matrix3 {
   void setColumn(int column, Vector3 arg) {
     final argStorage = arg._v3storage;
     final entry = column * 3;
-    _m3storage[entry + 2] = argStorage[2];
-    _m3storage[entry + 1] = argStorage[1];
-    _m3storage[entry + 0] = argStorage[0];
+    storage[entry + 2] = argStorage[2];
+    storage[entry + 1] = argStorage[1];
+    storage[entry + 0] = argStorage[0];
   }
 
   /// Gets the [column] of the matrix
@@ -300,9 +336,9 @@ class Matrix3 {
     final r = Vector3.zero();
     final rStorage = r._v3storage;
     final entry = column * 3;
-    rStorage[2] = _m3storage[entry + 2];
-    rStorage[1] = _m3storage[entry + 1];
-    rStorage[0] = _m3storage[entry + 0];
+    rStorage[2] = storage[entry + 2];
+    rStorage[1] = storage[entry + 1];
+    rStorage[0] = storage[entry + 0];
     return r;
   }
 
@@ -311,16 +347,16 @@ class Matrix3 {
 
   /// Copy this into [arg].
   Matrix3 copyInto(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    argStorage[0] = _m3storage[0];
-    argStorage[1] = _m3storage[1];
-    argStorage[2] = _m3storage[2];
-    argStorage[3] = _m3storage[3];
-    argStorage[4] = _m3storage[4];
-    argStorage[5] = _m3storage[5];
-    argStorage[6] = _m3storage[6];
-    argStorage[7] = _m3storage[7];
-    argStorage[8] = _m3storage[8];
+    final argStorage = arg.storage;
+    argStorage[0] = storage[0];
+    argStorage[1] = storage[1];
+    argStorage[2] = storage[2];
+    argStorage[3] = storage[3];
+    argStorage[4] = storage[4];
+    argStorage[5] = storage[5];
+    argStorage[6] = storage[6];
+    argStorage[7] = storage[7];
+    argStorage[8] = storage[8];
     return arg;
   }
 
@@ -349,28 +385,28 @@ class Matrix3 {
 
   /// Zeros this.
   void setZero() {
-    _m3storage[0] = 0.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 0.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 0.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 0.0;
   }
 
   /// Makes this into the identity matrix.
   void setIdentity() {
-    _m3storage[0] = 1.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 1.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 1.0;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Returns the tranpose of this.
@@ -379,67 +415,67 @@ class Matrix3 {
   /// Transpose this.
   void transpose() {
     double temp;
-    temp = _m3storage[3];
-    _m3storage[3] = _m3storage[1];
-    _m3storage[1] = temp;
-    temp = _m3storage[6];
-    _m3storage[6] = _m3storage[2];
-    _m3storage[2] = temp;
-    temp = _m3storage[7];
-    _m3storage[7] = _m3storage[5];
-    _m3storage[5] = temp;
+    temp = storage[3];
+    storage[3] = storage[1];
+    storage[1] = temp;
+    temp = storage[6];
+    storage[6] = storage[2];
+    storage[2] = temp;
+    temp = storage[7];
+    storage[7] = storage[5];
+    storage[5] = temp;
   }
 
   /// Returns the component wise absolute value of this.
   Matrix3 absolute() {
     final r = Matrix3.zero();
-    final rStorage = r._m3storage;
-    rStorage[0] = _m3storage[0].abs();
-    rStorage[1] = _m3storage[1].abs();
-    rStorage[2] = _m3storage[2].abs();
-    rStorage[3] = _m3storage[3].abs();
-    rStorage[4] = _m3storage[4].abs();
-    rStorage[5] = _m3storage[5].abs();
-    rStorage[6] = _m3storage[6].abs();
-    rStorage[7] = _m3storage[7].abs();
-    rStorage[8] = _m3storage[8].abs();
+    final rStorage = r.storage;
+    rStorage[0] = storage[0].abs();
+    rStorage[1] = storage[1].abs();
+    rStorage[2] = storage[2].abs();
+    rStorage[3] = storage[3].abs();
+    rStorage[4] = storage[4].abs();
+    rStorage[5] = storage[5].abs();
+    rStorage[6] = storage[6].abs();
+    rStorage[7] = storage[7].abs();
+    rStorage[8] = storage[8].abs();
     return r;
   }
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    final x = _m3storage[0] *
-        ((_m3storage[4] * _m3storage[8]) - (_m3storage[5] * _m3storage[7]));
-    final y = _m3storage[1] *
-        ((_m3storage[3] * _m3storage[8]) - (_m3storage[5] * _m3storage[6]));
-    final z = _m3storage[2] *
-        ((_m3storage[3] * _m3storage[7]) - (_m3storage[4] * _m3storage[6]));
+    final x =
+        storage[0] * ((storage[4] * storage[8]) - (storage[5] * storage[7]));
+    final y =
+        storage[1] * ((storage[3] * storage[8]) - (storage[5] * storage[6]));
+    final z =
+        storage[2] * ((storage[3] * storage[7]) - (storage[4] * storage[6]));
     return x - y + z;
   }
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector3 v) {
     final vStorage = v._v3storage;
-    return _m3storage[i] * vStorage[0] +
-        _m3storage[3 + i] * vStorage[1] +
-        _m3storage[6 + i] * vStorage[2];
+    return storage[i] * vStorage[0] +
+        storage[3 + i] * vStorage[1] +
+        storage[6 + i] * vStorage[2];
   }
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector3 v) {
     final vStorage = v._v3storage;
-    return _m3storage[j * 3] * vStorage[0] +
-        _m3storage[j * 3 + 1] * vStorage[1] +
-        _m3storage[j * 3 + 2] * vStorage[2];
+    return storage[j * 3] * vStorage[0] +
+        storage[j * 3 + 1] * vStorage[1] +
+        storage[j * 3 + 2] * vStorage[2];
   }
 
   /// Returns the trace of the matrix. The trace of a matrix is the sum of
   /// the diagonal entries.
   double trace() {
     var t = 0.0;
-    t += _m3storage[0];
-    t += _m3storage[4];
-    t += _m3storage[8];
+    t += storage[0];
+    t += storage[4];
+    t += storage[8];
     return t;
   }
 
@@ -448,23 +484,23 @@ class Matrix3 {
     var norm = 0.0;
     {
       var row_norm = 0.0;
-      row_norm += _m3storage[0].abs();
-      row_norm += _m3storage[1].abs();
-      row_norm += _m3storage[2].abs();
+      row_norm += storage[0].abs();
+      row_norm += storage[1].abs();
+      row_norm += storage[2].abs();
       norm = row_norm > norm ? row_norm : norm;
     }
     {
       var row_norm = 0.0;
-      row_norm += _m3storage[3].abs();
-      row_norm += _m3storage[4].abs();
-      row_norm += _m3storage[5].abs();
+      row_norm += storage[3].abs();
+      row_norm += storage[4].abs();
+      row_norm += storage[5].abs();
       norm = row_norm > norm ? row_norm : norm;
     }
     {
       var row_norm = 0.0;
-      row_norm += _m3storage[6].abs();
-      row_norm += _m3storage[7].abs();
-      row_norm += _m3storage[8].abs();
+      row_norm += storage[6].abs();
+      row_norm += storage[7].abs();
+      row_norm += storage[8].abs();
       norm = row_norm > norm ? row_norm : norm;
     }
     return norm;
@@ -497,7 +533,7 @@ class Matrix3 {
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final argStorage = arg._m3storage;
+    final argStorage = arg.storage;
     final ix = invDet *
         (argStorage[4] * argStorage[8] - argStorage[5] * argStorage[7]);
     final iy = invDet *
@@ -516,15 +552,15 @@ class Matrix3 {
         (argStorage[1] * argStorage[6] - argStorage[0] * argStorage[7]);
     final kz = invDet *
         (argStorage[0] * argStorage[4] - argStorage[1] * argStorage[3]);
-    _m3storage[0] = ix;
-    _m3storage[1] = iy;
-    _m3storage[2] = iz;
-    _m3storage[3] = jx;
-    _m3storage[4] = jy;
-    _m3storage[5] = jz;
-    _m3storage[6] = kx;
-    _m3storage[7] = ky;
-    _m3storage[8] = kz;
+    storage[0] = ix;
+    storage[1] = iy;
+    storage[2] = iz;
+    storage[3] = jx;
+    storage[4] = jy;
+    storage[5] = jz;
+    storage[6] = kx;
+    storage[7] = ky;
+    storage[8] = kz;
     return det;
   }
 
@@ -538,82 +574,82 @@ class Matrix3 {
   void setRotationX(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = 1.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = c;
-    _m3storage[5] = s;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = -s;
-    _m3storage[8] = c;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = c;
+    storage[5] = s;
+    storage[6] = 0.0;
+    storage[7] = -s;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Y
   void setRotationY(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = c;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = s;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 1.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = -s;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = c;
+    storage[0] = c;
+    storage[1] = 0.0;
+    storage[2] = s;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = -s;
+    storage[7] = 0.0;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Z
   void setRotationZ(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = c;
-    _m3storage[1] = s;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = -s;
-    _m3storage[4] = c;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 1.0;
+    storage[0] = c;
+    storage[1] = s;
+    storage[2] = 0.0;
+    storage[3] = -s;
+    storage[4] = c;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
   void scaleAdjoint(double scale) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    _m3storage[0] = (m11 * m22 - m12 * m21) * scale;
-    _m3storage[1] = (m12 * m20 - m10 * m22) * scale;
-    _m3storage[2] = (m10 * m21 - m11 * m20) * scale;
-    _m3storage[3] = (m02 * m21 - m01 * m22) * scale;
-    _m3storage[4] = (m00 * m22 - m02 * m20) * scale;
-    _m3storage[5] = (m01 * m20 - m00 * m21) * scale;
-    _m3storage[6] = (m01 * m12 - m02 * m11) * scale;
-    _m3storage[7] = (m02 * m10 - m00 * m12) * scale;
-    _m3storage[8] = (m00 * m11 - m01 * m10) * scale;
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    storage[0] = (m11 * m22 - m12 * m21) * scale;
+    storage[1] = (m12 * m20 - m10 * m22) * scale;
+    storage[2] = (m10 * m21 - m11 * m20) * scale;
+    storage[3] = (m02 * m21 - m01 * m22) * scale;
+    storage[4] = (m00 * m22 - m02 * m20) * scale;
+    storage[5] = (m01 * m20 - m00 * m21) * scale;
+    storage[6] = (m01 * m12 - m02 * m11) * scale;
+    storage[7] = (m02 * m10 - m00 * m12) * scale;
+    storage[8] = (m00 * m11 - m01 * m10) * scale;
   }
 
   /// Rotates [arg] by the absolute rotation of this
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector3 absoluteRotate(Vector3 arg) {
-    final m00 = _m3storage[0].abs();
-    final m01 = _m3storage[3].abs();
-    final m02 = _m3storage[6].abs();
-    final m10 = _m3storage[1].abs();
-    final m11 = _m3storage[4].abs();
-    final m12 = _m3storage[7].abs();
-    final m20 = _m3storage[2].abs();
-    final m21 = _m3storage[5].abs();
-    final m22 = _m3storage[8].abs();
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m02 = storage[6].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
+    final m12 = storage[7].abs();
+    final m20 = storage[2].abs();
+    final m21 = storage[5].abs();
+    final m22 = storage[8].abs();
     final argStorage = arg._v3storage;
     final x = argStorage[0];
     final y = argStorage[1];
@@ -628,10 +664,10 @@ class Matrix3 {
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector2 absoluteRotate2(Vector2 arg) {
-    final m00 = _m3storage[0].abs();
-    final m01 = _m3storage[3].abs();
-    final m10 = _m3storage[1].abs();
-    final m11 = _m3storage[4].abs();
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
     final argStorage = arg.storage;
     final x = argStorage[0];
     final y = argStorage[1];
@@ -643,12 +679,12 @@ class Matrix3 {
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) {
     final argStorage = arg.storage;
-    final x_ = (_m3storage[0] * argStorage[0]) +
-        (_m3storage[3] * argStorage[1]) +
-        _m3storage[6];
-    final y_ = (_m3storage[1] * argStorage[0]) +
-        (_m3storage[4] * argStorage[1]) +
-        _m3storage[7];
+    final x_ = (storage[0] * argStorage[0]) +
+        (storage[3] * argStorage[1]) +
+        storage[6];
+    final y_ = (storage[1] * argStorage[0]) +
+        (storage[4] * argStorage[1]) +
+        storage[7];
     argStorage[0] = x_;
     argStorage[1] = y_;
     return arg;
@@ -656,15 +692,15 @@ class Matrix3 {
 
   /// Scales this by [scale].
   void scale(double scale) {
-    _m3storage[0] = _m3storage[0] * scale;
-    _m3storage[1] = _m3storage[1] * scale;
-    _m3storage[2] = _m3storage[2] * scale;
-    _m3storage[3] = _m3storage[3] * scale;
-    _m3storage[4] = _m3storage[4] * scale;
-    _m3storage[5] = _m3storage[5] * scale;
-    _m3storage[6] = _m3storage[6] * scale;
-    _m3storage[7] = _m3storage[7] * scale;
-    _m3storage[8] = _m3storage[8] * scale;
+    storage[0] = storage[0] * scale;
+    storage[1] = storage[1] * scale;
+    storage[2] = storage[2] * scale;
+    storage[3] = storage[3] * scale;
+    storage[4] = storage[4] * scale;
+    storage[5] = storage[5] * scale;
+    storage[6] = storage[6] * scale;
+    storage[7] = storage[7] * scale;
+    storage[8] = storage[8] * scale;
   }
 
   /// Create a copy of this and scale it by [scale].
@@ -672,57 +708,57 @@ class Matrix3 {
 
   /// Add [o] to this.
   void add(Matrix3 o) {
-    final oStorage = o._m3storage;
-    _m3storage[0] = _m3storage[0] + oStorage[0];
-    _m3storage[1] = _m3storage[1] + oStorage[1];
-    _m3storage[2] = _m3storage[2] + oStorage[2];
-    _m3storage[3] = _m3storage[3] + oStorage[3];
-    _m3storage[4] = _m3storage[4] + oStorage[4];
-    _m3storage[5] = _m3storage[5] + oStorage[5];
-    _m3storage[6] = _m3storage[6] + oStorage[6];
-    _m3storage[7] = _m3storage[7] + oStorage[7];
-    _m3storage[8] = _m3storage[8] + oStorage[8];
+    final oStorage = o.storage;
+    storage[0] = storage[0] + oStorage[0];
+    storage[1] = storage[1] + oStorage[1];
+    storage[2] = storage[2] + oStorage[2];
+    storage[3] = storage[3] + oStorage[3];
+    storage[4] = storage[4] + oStorage[4];
+    storage[5] = storage[5] + oStorage[5];
+    storage[6] = storage[6] + oStorage[6];
+    storage[7] = storage[7] + oStorage[7];
+    storage[8] = storage[8] + oStorage[8];
   }
 
   /// Subtract [o] from this.
   void sub(Matrix3 o) {
-    final oStorage = o._m3storage;
-    _m3storage[0] = _m3storage[0] - oStorage[0];
-    _m3storage[1] = _m3storage[1] - oStorage[1];
-    _m3storage[2] = _m3storage[2] - oStorage[2];
-    _m3storage[3] = _m3storage[3] - oStorage[3];
-    _m3storage[4] = _m3storage[4] - oStorage[4];
-    _m3storage[5] = _m3storage[5] - oStorage[5];
-    _m3storage[6] = _m3storage[6] - oStorage[6];
-    _m3storage[7] = _m3storage[7] - oStorage[7];
-    _m3storage[8] = _m3storage[8] - oStorage[8];
+    final oStorage = o.storage;
+    storage[0] = storage[0] - oStorage[0];
+    storage[1] = storage[1] - oStorage[1];
+    storage[2] = storage[2] - oStorage[2];
+    storage[3] = storage[3] - oStorage[3];
+    storage[4] = storage[4] - oStorage[4];
+    storage[5] = storage[5] - oStorage[5];
+    storage[6] = storage[6] - oStorage[6];
+    storage[7] = storage[7] - oStorage[7];
+    storage[8] = storage[8] - oStorage[8];
   }
 
   /// Negate this.
   void negate() {
-    _m3storage[0] = -_m3storage[0];
-    _m3storage[1] = -_m3storage[1];
-    _m3storage[2] = -_m3storage[2];
-    _m3storage[3] = -_m3storage[3];
-    _m3storage[4] = -_m3storage[4];
-    _m3storage[5] = -_m3storage[5];
-    _m3storage[6] = -_m3storage[6];
-    _m3storage[7] = -_m3storage[7];
-    _m3storage[8] = -_m3storage[8];
+    storage[0] = -storage[0];
+    storage[1] = -storage[1];
+    storage[2] = -storage[2];
+    storage[3] = -storage[3];
+    storage[4] = -storage[4];
+    storage[5] = -storage[5];
+    storage[6] = -storage[6];
+    storage[7] = -storage[7];
+    storage[8] = -storage[8];
   }
 
   /// Multiply this by [arg].
   void multiply(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final argStorage = arg.storage;
     final n00 = argStorage[0];
     final n01 = argStorage[3];
     final n02 = argStorage[6];
@@ -732,79 +768,79 @@ class Matrix3 {
     final n20 = argStorage[2];
     final n21 = argStorage[5];
     final n22 = argStorage[8];
-    _m3storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
-    _m3storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
-    _m3storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
-    _m3storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
-    _m3storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
-    _m3storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
-    _m3storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
-    _m3storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
-    _m3storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
+    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
   /// Create a copy of this and multiply it by [arg].
   Matrix3 multiplied(Matrix3 arg) => clone()..multiply(arg);
 
   void transposeMultiply(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[1];
-    final m02 = _m3storage[2];
-    final m10 = _m3storage[3];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[5];
-    final m20 = _m3storage[6];
-    final m21 = _m3storage[7];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
-    _m3storage[0] =
+    final m00 = storage[0];
+    final m01 = storage[1];
+    final m02 = storage[2];
+    final m10 = storage[3];
+    final m11 = storage[4];
+    final m12 = storage[5];
+    final m20 = storage[6];
+    final m21 = storage[7];
+    final m22 = storage[8];
+    final argStorage = arg.storage;
+    storage[0] =
         (m00 * argStorage[0]) + (m01 * argStorage[1]) + (m02 * argStorage[2]);
-    _m3storage[3] =
+    storage[3] =
         (m00 * argStorage[3]) + (m01 * argStorage[4]) + (m02 * argStorage[5]);
-    _m3storage[6] =
+    storage[6] =
         (m00 * argStorage[6]) + (m01 * argStorage[7]) + (m02 * argStorage[8]);
-    _m3storage[1] =
+    storage[1] =
         (m10 * argStorage[0]) + (m11 * argStorage[1]) + (m12 * argStorage[2]);
-    _m3storage[4] =
+    storage[4] =
         (m10 * argStorage[3]) + (m11 * argStorage[4]) + (m12 * argStorage[5]);
-    _m3storage[7] =
+    storage[7] =
         (m10 * argStorage[6]) + (m11 * argStorage[7]) + (m12 * argStorage[8]);
-    _m3storage[2] =
+    storage[2] =
         (m20 * argStorage[0]) + (m21 * argStorage[1]) + (m22 * argStorage[2]);
-    _m3storage[5] =
+    storage[5] =
         (m20 * argStorage[3]) + (m21 * argStorage[4]) + (m22 * argStorage[5]);
-    _m3storage[8] =
+    storage[8] =
         (m20 * argStorage[6]) + (m21 * argStorage[7]) + (m22 * argStorage[8]);
   }
 
   void multiplyTranspose(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
-    _m3storage[0] =
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final argStorage = arg.storage;
+    storage[0] =
         (m00 * argStorage[0]) + (m01 * argStorage[3]) + (m02 * argStorage[6]);
-    _m3storage[3] =
+    storage[3] =
         (m00 * argStorage[1]) + (m01 * argStorage[4]) + (m02 * argStorage[7]);
-    _m3storage[6] =
+    storage[6] =
         (m00 * argStorage[2]) + (m01 * argStorage[5]) + (m02 * argStorage[8]);
-    _m3storage[1] =
+    storage[1] =
         (m10 * argStorage[0]) + (m11 * argStorage[3]) + (m12 * argStorage[6]);
-    _m3storage[4] =
+    storage[4] =
         (m10 * argStorage[1]) + (m11 * argStorage[4]) + (m12 * argStorage[7]);
-    _m3storage[7] =
+    storage[7] =
         (m10 * argStorage[2]) + (m11 * argStorage[5]) + (m12 * argStorage[8]);
-    _m3storage[2] =
+    storage[2] =
         (m20 * argStorage[0]) + (m21 * argStorage[3]) + (m22 * argStorage[6]);
-    _m3storage[5] =
+    storage[5] =
         (m20 * argStorage[1]) + (m21 * argStorage[4]) + (m22 * argStorage[7]);
-    _m3storage[8] =
+    storage[8] =
         (m20 * argStorage[2]) + (m21 * argStorage[5]) + (m22 * argStorage[8]);
   }
 
@@ -812,15 +848,15 @@ class Matrix3 {
   /// this.
   Vector3 transform(Vector3 arg) {
     final argStorage = arg._v3storage;
-    final x_ = (_m3storage[0] * argStorage[0]) +
-        (_m3storage[3] * argStorage[1]) +
-        (_m3storage[6] * argStorage[2]);
-    final y_ = (_m3storage[1] * argStorage[0]) +
-        (_m3storage[4] * argStorage[1]) +
-        (_m3storage[7] * argStorage[2]);
-    final z_ = (_m3storage[2] * argStorage[0]) +
-        (_m3storage[5] * argStorage[1]) +
-        (_m3storage[8] * argStorage[2]);
+    final x_ = (storage[0] * argStorage[0]) +
+        (storage[3] * argStorage[1]) +
+        (storage[6] * argStorage[2]);
+    final y_ = (storage[1] * argStorage[0]) +
+        (storage[4] * argStorage[1]) +
+        (storage[7] * argStorage[2]);
+    final z_ = (storage[2] * argStorage[0]) +
+        (storage[5] * argStorage[1]) +
+        (storage[8] * argStorage[2]);
     arg
       ..x = x_
       ..y = y_
@@ -843,29 +879,29 @@ class Matrix3 {
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<num> array, [int offset = 0]) {
     final i = offset;
-    array[i + 8] = _m3storage[8];
-    array[i + 7] = _m3storage[7];
-    array[i + 6] = _m3storage[6];
-    array[i + 5] = _m3storage[5];
-    array[i + 4] = _m3storage[4];
-    array[i + 3] = _m3storage[3];
-    array[i + 2] = _m3storage[2];
-    array[i + 1] = _m3storage[1];
-    array[i + 0] = _m3storage[0];
+    array[i + 8] = storage[8];
+    array[i + 7] = storage[7];
+    array[i + 6] = storage[6];
+    array[i + 5] = storage[5];
+    array[i + 4] = storage[4];
+    array[i + 3] = storage[3];
+    array[i + 2] = storage[2];
+    array[i + 1] = storage[1];
+    array[i + 0] = storage[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
     final i = offset;
-    _m3storage[8] = array[i + 8];
-    _m3storage[7] = array[i + 7];
-    _m3storage[6] = array[i + 6];
-    _m3storage[5] = array[i + 5];
-    _m3storage[4] = array[i + 4];
-    _m3storage[3] = array[i + 3];
-    _m3storage[2] = array[i + 2];
-    _m3storage[1] = array[i + 1];
-    _m3storage[0] = array[i + 0];
+    storage[8] = array[i + 8];
+    storage[7] = array[i + 7];
+    storage[6] = array[i + 6];
+    storage[5] = array[i + 5];
+    storage[4] = array[i + 4];
+    storage[3] = array[i + 3];
+    storage[2] = array[i + 2];
+    storage[1] = array[i + 1];
+    storage[0] = array[i + 0];
   }
 
   /// Multiply this to each set of xyz values in [array] starting at [offset].
@@ -881,53 +917,53 @@ class Matrix3 {
   }
 
   Vector3 get right {
-    final x = _m3storage[0];
-    final y = _m3storage[1];
-    final z = _m3storage[2];
+    final x = storage[0];
+    final y = storage[1];
+    final z = storage[2];
     return Vector3(x, y, z);
   }
 
   Vector3 get up {
-    final x = _m3storage[3];
-    final y = _m3storage[4];
-    final z = _m3storage[5];
+    final x = storage[3];
+    final y = storage[4];
+    final z = storage[5];
     return Vector3(x, y, z);
   }
 
   Vector3 get forward {
-    final x = _m3storage[6];
-    final y = _m3storage[7];
-    final z = _m3storage[8];
+    final x = storage[6];
+    final y = storage[7];
+    final z = storage[8];
     return Vector3(x, y, z);
   }
 
   /// Is this the identity matrix?
   bool isIdentity() =>
-      _m3storage[0] == 1.0 // col 1
+      storage[0] == 1.0 // col 1
       &&
-      _m3storage[1] == 0.0 &&
-      _m3storage[2] == 0.0 &&
-      _m3storage[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      _m3storage[4] == 1.0 &&
-      _m3storage[5] == 0.0 &&
-      _m3storage[6] == 0.0 // col 3
+      storage[4] == 1.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      _m3storage[7] == 0.0 &&
-      _m3storage[8] == 1.0;
+      storage[7] == 0.0 &&
+      storage[8] == 1.0;
 
   /// Is this the zero matrix?
   bool isZero() =>
-      _m3storage[0] == 0.0 // col 1
+      storage[0] == 0.0 // col 1
       &&
-      _m3storage[1] == 0.0 &&
-      _m3storage[2] == 0.0 &&
-      _m3storage[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      _m3storage[4] == 0.0 &&
-      _m3storage[5] == 0.0 &&
-      _m3storage[6] == 0.0 // col 3
+      storage[4] == 0.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      _m3storage[7] == 0.0 &&
-      _m3storage[8] == 0.0;
+      storage[7] == 0.0 &&
+      storage[8] == 0.0;
 }

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -633,7 +633,7 @@ class Matrix3 {
     final m01 = _m3storage[3].abs();
     final m10 = _m3storage[1].abs();
     final m11 = _m3storage[4].abs();
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = argStorage[0];
     final y = argStorage[1];
     argStorage[0] = x * m00 + y * m01;
@@ -643,7 +643,7 @@ class Matrix3 {
 
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x_ = (_m3storage[0] * argStorage[0]) +
         (_m3storage[3] * argStorage[1]) +
         _m3storage[6];

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -212,11 +212,10 @@ class Matrix3 {
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    _m3storage[0] = argStorage[0];
-    _m3storage[1] = argStorage[1];
-    _m3storage[3] = argStorage[2];
-    _m3storage[4] = argStorage[3];
+    _m3storage[0] = arg[0];
+    _m3storage[1] = arg[1];
+    _m3storage[3] = arg[2];
+    _m3storage[4] = arg[3];
   }
 
   /// Returns a printable string

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -16,8 +16,8 @@ class Matrix3 {
     final a12 = A.entry(0, 1);
     final a21 = A.entry(1, 0);
     final a22 = A.entry(1, 1);
-    final bx = b.x - A.storage[6];
-    final by = b.y - A.storage[7];
+    final bx = b.x - A[6];
+    final by = b.y - A[7];
     var det = a11 * a22 - a12 * a21;
 
     if (det != 0.0) {
@@ -162,7 +162,7 @@ class Matrix3 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    return storage[index(row, col)];
+    return this[index(row, col)];
   }
 
   /// Set value at [row], [col] to be [v].
@@ -170,88 +170,82 @@ class Matrix3 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    storage[index(row, col)] = v;
+    this[index(row, col)] = v;
   }
 
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
-    storage[8] = arg8;
-    storage[7] = arg7;
-    storage[6] = arg6;
-    storage[5] = arg5;
-    storage[4] = arg4;
-    storage[3] = arg3;
-    storage[2] = arg2;
-    storage[1] = arg1;
-    storage[0] = arg0;
+    this[0] = arg0;
+    this[1] = arg1;
+    this[2] = arg2;
+    this[3] = arg3;
+    this[4] = arg4;
+    this[5] = arg5;
+    this[6] = arg6;
+    this[7] = arg7;
+    this[8] = arg8;
   }
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
-    final arg0Storage = arg0._v3storage;
-    final arg1Storage = arg1._v3storage;
-    final arg2Storage = arg2._v3storage;
-    storage[0] = arg0Storage[0];
-    storage[1] = arg0Storage[1];
-    storage[2] = arg0Storage[2];
-    storage[3] = arg1Storage[0];
-    storage[4] = arg1Storage[1];
-    storage[5] = arg1Storage[2];
-    storage[6] = arg2Storage[0];
-    storage[7] = arg2Storage[1];
-    storage[8] = arg2Storage[2];
+    this[0] = arg0[0];
+    this[1] = arg0[1];
+    this[2] = arg0[2];
+    this[3] = arg1[0];
+    this[4] = arg1[1];
+    this[5] = arg1[2];
+    this[6] = arg2[0];
+    this[7] = arg2[1];
+    this[8] = arg2[2];
   }
 
-  /// Sets the entire matrix to the matrix in [arg].
-  void setFrom(Matrix3 arg) {
-    final argStorage = arg.storage;
-    storage[8] = argStorage[8];
-    storage[7] = argStorage[7];
-    storage[6] = argStorage[6];
-    storage[5] = argStorage[5];
-    storage[4] = argStorage[4];
-    storage[3] = argStorage[3];
-    storage[2] = argStorage[2];
-    storage[1] = argStorage[1];
-    storage[0] = argStorage[0];
+  /// Sets the entire matrix to the matrix in [other].
+  void setFrom(Matrix3 other) {
+    this[0] = other[0];
+    this[1] = other[1];
+    this[2] = other[2];
+    this[3] = other[3];
+    this[4] = other[4];
+    this[5] = other[5];
+    this[6] = other[6];
+    this[7] = other[7];
+    this[8] = other[8];
   }
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector3 u, Vector3 v) {
-    final uStorage = u._v3storage;
-    final vStorage = v._v3storage;
-    storage[0] = uStorage[0] * vStorage[0];
-    storage[1] = uStorage[0] * vStorage[1];
-    storage[2] = uStorage[0] * vStorage[2];
-    storage[3] = uStorage[1] * vStorage[0];
-    storage[4] = uStorage[1] * vStorage[1];
-    storage[5] = uStorage[1] * vStorage[2];
-    storage[6] = uStorage[2] * vStorage[0];
-    storage[7] = uStorage[2] * vStorage[1];
-    storage[8] = uStorage[2] * vStorage[2];
+    this[0] = u[0] * v[0];
+    this[1] = u[0] * v[1];
+    this[2] = u[0] * v[2];
+    this[3] = u[1] * v[0];
+    this[4] = u[1] * v[1];
+    this[5] = u[1] * v[2];
+    this[6] = u[2] * v[0];
+    this[7] = u[2] * v[1];
+    this[8] = u[2] * v[2];
   }
 
   /// Set the diagonal of the matrix.
   void splatDiagonal(double arg) {
-    storage[0] = arg;
-    storage[4] = arg;
-    storage[8] = arg;
+    this[0] = arg;
+    this[4] = arg;
+    this[8] = arg;
   }
 
   /// Set the diagonal of the matrix.
   void setDiagonal(Vector3 arg) {
-    storage[0] = arg.storage[0];
-    storage[4] = arg.storage[1];
-    storage[8] = arg.storage[2];
+    this[0] = arg[0];
+    this[4] = arg[1];
+    this[8] = arg[2];
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    storage[0] = arg[0];
-    storage[1] = arg[1];
-    storage[3] = arg[2];
-    storage[4] = arg[3];
+    this[0] = arg[0];
+    this[1] = arg[1];
+    this[3] = arg[2];
+    this[4] = arg[3];
   }
 
   /// Returns a printable string
@@ -273,15 +267,15 @@ class Matrix3 {
   @override
   bool operator ==(Object other) =>
       (other is Matrix3) &&
-      (storage[0] == other.storage[0]) &&
-      (storage[1] == other.storage[1]) &&
-      (storage[2] == other.storage[2]) &&
-      (storage[3] == other.storage[3]) &&
-      (storage[4] == other.storage[4]) &&
-      (storage[5] == other.storage[5]) &&
-      (storage[6] == other.storage[6]) &&
-      (storage[7] == other.storage[7]) &&
-      (storage[8] == other.storage[8]);
+      (this[0] == other[0]) &&
+      (this[1] == other[1]) &&
+      (this[2] == other[2]) &&
+      (this[3] == other[3]) &&
+      (this[4] == other[4]) &&
+      (this[5] == other[5]) &&
+      (this[6] == other[6]) &&
+      (this[7] == other[7]) &&
+      (this[8] == other[8]);
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -306,107 +300,85 @@ class Matrix3 {
 
   /// Assigns the [row] of to [arg].
   void setRow(int row, Vector3 arg) {
-    final argStorage = arg._v3storage;
-    storage[index(row, 0)] = argStorage[0];
-    storage[index(row, 1)] = argStorage[1];
-    storage[index(row, 2)] = argStorage[2];
+    this[index(row, 0)] = arg[0];
+    this[index(row, 1)] = arg[1];
+    this[index(row, 2)] = arg[2];
   }
 
   /// Gets the [row] of the matrix
-  Vector3 getRow(int row) {
-    final r = Vector3.zero();
-    final rStorage = r._v3storage;
-    rStorage[0] = storage[index(row, 0)];
-    rStorage[1] = storage[index(row, 1)];
-    rStorage[2] = storage[index(row, 2)];
-    return r;
-  }
+  Vector3 getRow(int row) => Vector3(
+        this[index(row, 0)],
+        this[index(row, 1)],
+        this[index(row, 2)],
+      );
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector3 arg) {
-    final argStorage = arg._v3storage;
     final entry = column * 3;
-    storage[entry + 2] = argStorage[2];
-    storage[entry + 1] = argStorage[1];
-    storage[entry + 0] = argStorage[0];
+    this[entry + 2] = arg[2];
+    this[entry + 1] = arg[1];
+    this[entry + 0] = arg[0];
   }
 
   /// Gets the [column] of the matrix
   Vector3 getColumn(int column) {
-    final r = Vector3.zero();
-    final rStorage = r._v3storage;
     final entry = column * 3;
-    rStorage[2] = storage[entry + 2];
-    rStorage[1] = storage[entry + 1];
-    rStorage[0] = storage[entry + 0];
-    return r;
+    return Vector3(this[entry + 0], this[entry + 1], this[entry + 2]);
   }
 
   /// Clone of this.
   Matrix3 clone() => Matrix3.copy(this);
 
-  /// Copy this into [arg].
-  Matrix3 copyInto(Matrix3 arg) {
-    final argStorage = arg.storage;
-    argStorage[0] = storage[0];
-    argStorage[1] = storage[1];
-    argStorage[2] = storage[2];
-    argStorage[3] = storage[3];
-    argStorage[4] = storage[4];
-    argStorage[5] = storage[5];
-    argStorage[6] = storage[6];
-    argStorage[7] = storage[7];
-    argStorage[8] = storage[8];
-    return arg;
+  /// Copy this into [other].
+  Matrix3 copyInto(Matrix3 other) => other..setFrom(this);
+
+  /// Returns a new vector or matrix by multiplying this with [other].
+  dynamic operator *(dynamic other) {
+    if (other is double) {
+      return scaled(other);
+    }
+    if (other is Vector3) {
+      return transformed(other);
+    }
+    if (other is Matrix3) {
+      return multiplied(other);
+    }
+    throw ArgumentError(other);
   }
 
-  /// Returns a new vector or matrix by multiplying this with [arg].
-  dynamic operator *(dynamic arg) {
-    if (arg is double) {
-      return scaled(arg);
-    }
-    if (arg is Vector3) {
-      return transformed(arg);
-    }
-    if (arg is Matrix3) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
-  }
+  /// Returns new matrix after component wise this + [other]
+  Matrix3 operator +(Matrix3 other) => clone()..add(other);
 
-  /// Returns new matrix after component wise this + [arg]
-  Matrix3 operator +(Matrix3 arg) => clone()..add(arg);
-
-  /// Returns new matrix after component wise this - [arg]
-  Matrix3 operator -(Matrix3 arg) => clone()..sub(arg);
+  /// Returns new matrix after component wise this - [other]
+  Matrix3 operator -(Matrix3 other) => clone()..sub(other);
 
   /// Returns new matrix -this
   Matrix3 operator -() => clone()..negate();
 
   /// Zeros this.
   void setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
-    storage[2] = 0.0;
-    storage[3] = 0.0;
-    storage[4] = 0.0;
-    storage[5] = 0.0;
-    storage[6] = 0.0;
-    storage[7] = 0.0;
-    storage[8] = 0.0;
+    this[0] = 0.0;
+    this[1] = 0.0;
+    this[2] = 0.0;
+    this[3] = 0.0;
+    this[4] = 0.0;
+    this[5] = 0.0;
+    this[6] = 0.0;
+    this[7] = 0.0;
+    this[8] = 0.0;
   }
 
   /// Makes this into the identity matrix.
   void setIdentity() {
-    storage[0] = 1.0;
-    storage[1] = 0.0;
-    storage[2] = 0.0;
-    storage[3] = 0.0;
-    storage[4] = 1.0;
-    storage[5] = 0.0;
-    storage[6] = 0.0;
-    storage[7] = 0.0;
-    storage[8] = 1.0;
+    this[0] = 1.0;
+    this[1] = 0.0;
+    this[2] = 0.0;
+    this[3] = 0.0;
+    this[4] = 1.0;
+    this[5] = 0.0;
+    this[6] = 0.0;
+    this[7] = 0.0;
+    this[8] = 1.0;
   }
 
   /// Returns the tranpose of this.
@@ -415,95 +387,62 @@ class Matrix3 {
   /// Transpose this.
   void transpose() {
     double temp;
-    temp = storage[3];
-    storage[3] = storage[1];
-    storage[1] = temp;
-    temp = storage[6];
-    storage[6] = storage[2];
-    storage[2] = temp;
-    temp = storage[7];
-    storage[7] = storage[5];
-    storage[5] = temp;
+    temp = this[3];
+    this[3] = this[1];
+    this[1] = temp;
+    temp = this[6];
+    this[6] = this[2];
+    this[2] = temp;
+    temp = this[7];
+    this[7] = this[5];
+    this[5] = temp;
   }
 
   /// Returns the component wise absolute value of this.
-  Matrix3 absolute() {
-    final r = Matrix3.zero();
-    final rStorage = r.storage;
-    rStorage[0] = storage[0].abs();
-    rStorage[1] = storage[1].abs();
-    rStorage[2] = storage[2].abs();
-    rStorage[3] = storage[3].abs();
-    rStorage[4] = storage[4].abs();
-    rStorage[5] = storage[5].abs();
-    rStorage[6] = storage[6].abs();
-    rStorage[7] = storage[7].abs();
-    rStorage[8] = storage[8].abs();
-    return r;
-  }
+  Matrix3 absolute() => Matrix3(
+        this[0].abs(),
+        this[1].abs(),
+        this[2].abs(),
+        this[3].abs(),
+        this[4].abs(),
+        this[5].abs(),
+        this[6].abs(),
+        this[7].abs(),
+        this[8].abs(),
+      );
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    final x =
-        storage[0] * ((storage[4] * storage[8]) - (storage[5] * storage[7]));
-    final y =
-        storage[1] * ((storage[3] * storage[8]) - (storage[5] * storage[6]));
-    final z =
-        storage[2] * ((storage[3] * storage[7]) - (storage[4] * storage[6]));
+    final x = this[0] * ((this[4] * this[8]) - (this[5] * this[7]));
+    final y = this[1] * ((this[3] * this[8]) - (this[5] * this[6]));
+    final z = this[2] * ((this[3] * this[7]) - (this[4] * this[6]));
     return x - y + z;
   }
 
   /// Returns the dot product of row [i] and [v].
-  double dotRow(int i, Vector3 v) {
-    final vStorage = v._v3storage;
-    return storage[i] * vStorage[0] +
-        storage[3 + i] * vStorage[1] +
-        storage[6 + i] * vStorage[2];
-  }
+  double dotRow(int i, Vector3 v) =>
+      this[i] * v[0] + this[3 + i] * v[1] + this[6 + i] * v[2];
 
   /// Returns the dot product of column [j] and [v].
-  double dotColumn(int j, Vector3 v) {
-    final vStorage = v._v3storage;
-    return storage[j * 3] * vStorage[0] +
-        storage[j * 3 + 1] * vStorage[1] +
-        storage[j * 3 + 2] * vStorage[2];
-  }
+  double dotColumn(int j, Vector3 v) =>
+      this[j * 3] * v[0] + this[j * 3 + 1] * v[1] + this[j * 3 + 2] * v[2];
 
   /// Returns the trace of the matrix. The trace of a matrix is the sum of
   /// the diagonal entries.
   double trace() {
     var t = 0.0;
-    t += storage[0];
-    t += storage[4];
-    t += storage[8];
+    t += this[0];
+    t += this[4];
+    t += this[8];
     return t;
   }
 
   /// Returns infinity norm of the matrix. Used for numerical analysis.
   double infinityNorm() {
-    var norm = 0.0;
-    {
-      var row_norm = 0.0;
-      row_norm += storage[0].abs();
-      row_norm += storage[1].abs();
-      row_norm += storage[2].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    {
-      var row_norm = 0.0;
-      row_norm += storage[3].abs();
-      row_norm += storage[4].abs();
-      row_norm += storage[5].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    {
-      var row_norm = 0.0;
-      row_norm += storage[6].abs();
-      row_norm += storage[7].abs();
-      row_norm += storage[8].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    return norm;
+    final row1 = this[0].abs() + this[1].abs() + this[2].abs();
+    final row2 = this[3].abs() + this[4].abs() + this[5].abs();
+    final row3 = this[6].abs() + this[7].abs() + this[8].abs();
+    return math.max(row1, math.max(row2, math.max(row3, 0)));
   }
 
   /// Returns relative error between this and [correct]
@@ -525,42 +464,32 @@ class Matrix3 {
   /// Invert the matrix. Returns the determinant.
   double invert() => copyInverse(this);
 
-  /// Set this matrix to be the inverse of [arg]
-  double copyInverse(Matrix3 arg) {
-    final det = arg.determinant();
+  /// Set this matrix to be the inverse of [other]
+  double copyInverse(Matrix3 other) {
+    final det = other.determinant();
     if (det == 0.0) {
-      setFrom(arg);
+      setFrom(other);
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final argStorage = arg.storage;
-    final ix = invDet *
-        (argStorage[4] * argStorage[8] - argStorage[5] * argStorage[7]);
-    final iy = invDet *
-        (argStorage[2] * argStorage[7] - argStorage[1] * argStorage[8]);
-    final iz = invDet *
-        (argStorage[1] * argStorage[5] - argStorage[2] * argStorage[4]);
-    final jx = invDet *
-        (argStorage[5] * argStorage[6] - argStorage[3] * argStorage[8]);
-    final jy = invDet *
-        (argStorage[0] * argStorage[8] - argStorage[2] * argStorage[6]);
-    final jz = invDet *
-        (argStorage[2] * argStorage[3] - argStorage[0] * argStorage[5]);
-    final kx = invDet *
-        (argStorage[3] * argStorage[7] - argStorage[4] * argStorage[6]);
-    final ky = invDet *
-        (argStorage[1] * argStorage[6] - argStorage[0] * argStorage[7]);
-    final kz = invDet *
-        (argStorage[0] * argStorage[4] - argStorage[1] * argStorage[3]);
-    storage[0] = ix;
-    storage[1] = iy;
-    storage[2] = iz;
-    storage[3] = jx;
-    storage[4] = jy;
-    storage[5] = jz;
-    storage[6] = kx;
-    storage[7] = ky;
-    storage[8] = kz;
+    final ix = invDet * (other[4] * other[8] - other[5] * other[7]);
+    final iy = invDet * (other[2] * other[7] - other[1] * other[8]);
+    final iz = invDet * (other[1] * other[5] - other[2] * other[4]);
+    final jx = invDet * (other[5] * other[6] - other[3] * other[8]);
+    final jy = invDet * (other[0] * other[8] - other[2] * other[6]);
+    final jz = invDet * (other[2] * other[3] - other[0] * other[5]);
+    final kx = invDet * (other[3] * other[7] - other[4] * other[6]);
+    final ky = invDet * (other[1] * other[6] - other[0] * other[7]);
+    final kz = invDet * (other[0] * other[4] - other[1] * other[3]);
+    this[0] = ix;
+    this[1] = iy;
+    this[2] = iz;
+    this[3] = jx;
+    this[4] = jy;
+    this[5] = jz;
+    this[6] = kx;
+    this[7] = ky;
+    this[8] = kz;
     return det;
   }
 
@@ -574,89 +503,88 @@ class Matrix3 {
   void setRotationX(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    storage[0] = 1.0;
-    storage[1] = 0.0;
-    storage[2] = 0.0;
-    storage[3] = 0.0;
-    storage[4] = c;
-    storage[5] = s;
-    storage[6] = 0.0;
-    storage[7] = -s;
-    storage[8] = c;
+    this[0] = 1.0;
+    this[1] = 0.0;
+    this[2] = 0.0;
+    this[3] = 0.0;
+    this[4] = c;
+    this[5] = s;
+    this[6] = 0.0;
+    this[7] = -s;
+    this[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Y
   void setRotationY(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    storage[0] = c;
-    storage[1] = 0.0;
-    storage[2] = s;
-    storage[3] = 0.0;
-    storage[4] = 1.0;
-    storage[5] = 0.0;
-    storage[6] = -s;
-    storage[7] = 0.0;
-    storage[8] = c;
+    this[0] = c;
+    this[1] = 0.0;
+    this[2] = s;
+    this[3] = 0.0;
+    this[4] = 1.0;
+    this[5] = 0.0;
+    this[6] = -s;
+    this[7] = 0.0;
+    this[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Z
   void setRotationZ(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    storage[0] = c;
-    storage[1] = s;
-    storage[2] = 0.0;
-    storage[3] = -s;
-    storage[4] = c;
-    storage[5] = 0.0;
-    storage[6] = 0.0;
-    storage[7] = 0.0;
-    storage[8] = 1.0;
+    this[0] = c;
+    this[1] = s;
+    this[2] = 0.0;
+    this[3] = -s;
+    this[4] = c;
+    this[5] = 0.0;
+    this[6] = 0.0;
+    this[7] = 0.0;
+    this[8] = 1.0;
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
   void scaleAdjoint(double scale) {
-    final m00 = storage[0];
-    final m01 = storage[3];
-    final m02 = storage[6];
-    final m10 = storage[1];
-    final m11 = storage[4];
-    final m12 = storage[7];
-    final m20 = storage[2];
-    final m21 = storage[5];
-    final m22 = storage[8];
-    storage[0] = (m11 * m22 - m12 * m21) * scale;
-    storage[1] = (m12 * m20 - m10 * m22) * scale;
-    storage[2] = (m10 * m21 - m11 * m20) * scale;
-    storage[3] = (m02 * m21 - m01 * m22) * scale;
-    storage[4] = (m00 * m22 - m02 * m20) * scale;
-    storage[5] = (m01 * m20 - m00 * m21) * scale;
-    storage[6] = (m01 * m12 - m02 * m11) * scale;
-    storage[7] = (m02 * m10 - m00 * m12) * scale;
-    storage[8] = (m00 * m11 - m01 * m10) * scale;
+    final m00 = this[0];
+    final m01 = this[3];
+    final m02 = this[6];
+    final m10 = this[1];
+    final m11 = this[4];
+    final m12 = this[7];
+    final m20 = this[2];
+    final m21 = this[5];
+    final m22 = this[8];
+    this[0] = (m11 * m22 - m12 * m21) * scale;
+    this[1] = (m12 * m20 - m10 * m22) * scale;
+    this[2] = (m10 * m21 - m11 * m20) * scale;
+    this[3] = (m02 * m21 - m01 * m22) * scale;
+    this[4] = (m00 * m22 - m02 * m20) * scale;
+    this[5] = (m01 * m20 - m00 * m21) * scale;
+    this[6] = (m01 * m12 - m02 * m11) * scale;
+    this[7] = (m02 * m10 - m00 * m12) * scale;
+    this[8] = (m00 * m11 - m01 * m10) * scale;
   }
 
   /// Rotates [arg] by the absolute rotation of this
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector3 absoluteRotate(Vector3 arg) {
-    final m00 = storage[0].abs();
-    final m01 = storage[3].abs();
-    final m02 = storage[6].abs();
-    final m10 = storage[1].abs();
-    final m11 = storage[4].abs();
-    final m12 = storage[7].abs();
-    final m20 = storage[2].abs();
-    final m21 = storage[5].abs();
-    final m22 = storage[8].abs();
-    final argStorage = arg._v3storage;
-    final x = argStorage[0];
-    final y = argStorage[1];
-    final z = argStorage[2];
-    argStorage[0] = x * m00 + y * m01 + z * m02;
-    argStorage[1] = x * m10 + y * m11 + z * m12;
-    argStorage[2] = x * m20 + y * m21 + z * m22;
+    final m00 = this[0].abs();
+    final m01 = this[3].abs();
+    final m02 = this[6].abs();
+    final m10 = this[1].abs();
+    final m11 = this[4].abs();
+    final m12 = this[7].abs();
+    final m20 = this[2].abs();
+    final m21 = this[5].abs();
+    final m22 = this[8].abs();
+    final x = arg[0];
+    final y = arg[1];
+    final z = arg[2];
+    arg[0] = x * m00 + y * m01 + z * m02;
+    arg[1] = x * m10 + y * m11 + z * m12;
+    arg[2] = x * m20 + y * m21 + z * m22;
     return arg;
   }
 
@@ -664,306 +592,261 @@ class Matrix3 {
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector2 absoluteRotate2(Vector2 arg) {
-    final m00 = storage[0].abs();
-    final m01 = storage[3].abs();
-    final m10 = storage[1].abs();
-    final m11 = storage[4].abs();
-    final argStorage = arg.storage;
-    final x = argStorage[0];
-    final y = argStorage[1];
-    argStorage[0] = x * m00 + y * m01;
-    argStorage[1] = x * m10 + y * m11;
+    final m00 = this[0].abs();
+    final m01 = this[3].abs();
+    final m10 = this[1].abs();
+    final m11 = this[4].abs();
+    final x = arg[0];
+    final y = arg[1];
+    arg[0] = x * m00 + y * m01;
+    arg[1] = x * m10 + y * m11;
     return arg;
   }
 
   /// Transforms [arg] with this.
-  Vector2 transform2(Vector2 arg) {
-    final argStorage = arg.storage;
-    final x_ = (storage[0] * argStorage[0]) +
-        (storage[3] * argStorage[1]) +
-        storage[6];
-    final y_ = (storage[1] * argStorage[0]) +
-        (storage[4] * argStorage[1]) +
-        storage[7];
-    argStorage[0] = x_;
-    argStorage[1] = y_;
-    return arg;
-  }
+  Vector2 transform2(Vector2 arg) => arg
+    ..setValues(
+      (this[0] * arg[0]) + (this[3] * arg[1]) + this[6],
+      (this[1] * arg[0]) + (this[4] * arg[1]) + this[7],
+    );
 
   /// Scales this by [scale].
   void scale(double scale) {
-    storage[0] = storage[0] * scale;
-    storage[1] = storage[1] * scale;
-    storage[2] = storage[2] * scale;
-    storage[3] = storage[3] * scale;
-    storage[4] = storage[4] * scale;
-    storage[5] = storage[5] * scale;
-    storage[6] = storage[6] * scale;
-    storage[7] = storage[7] * scale;
-    storage[8] = storage[8] * scale;
+    this[0] *= scale;
+    this[1] *= scale;
+    this[2] *= scale;
+    this[3] *= scale;
+    this[4] *= scale;
+    this[5] *= scale;
+    this[6] *= scale;
+    this[7] *= scale;
+    this[8] *= scale;
   }
 
   /// Create a copy of this and scale it by [scale].
   Matrix3 scaled(double scale) => clone()..scale(scale);
 
-  /// Add [o] to this.
-  void add(Matrix3 o) {
-    final oStorage = o.storage;
-    storage[0] = storage[0] + oStorage[0];
-    storage[1] = storage[1] + oStorage[1];
-    storage[2] = storage[2] + oStorage[2];
-    storage[3] = storage[3] + oStorage[3];
-    storage[4] = storage[4] + oStorage[4];
-    storage[5] = storage[5] + oStorage[5];
-    storage[6] = storage[6] + oStorage[6];
-    storage[7] = storage[7] + oStorage[7];
-    storage[8] = storage[8] + oStorage[8];
+  /// Add [other] to this.
+  void add(Matrix3 other) {
+    this[0] += other[0];
+    this[1] += other[1];
+    this[2] += other[2];
+    this[3] += other[3];
+    this[4] += other[4];
+    this[5] += other[5];
+    this[6] += other[6];
+    this[7] += other[7];
+    this[8] += other[8];
   }
 
-  /// Subtract [o] from this.
-  void sub(Matrix3 o) {
-    final oStorage = o.storage;
-    storage[0] = storage[0] - oStorage[0];
-    storage[1] = storage[1] - oStorage[1];
-    storage[2] = storage[2] - oStorage[2];
-    storage[3] = storage[3] - oStorage[3];
-    storage[4] = storage[4] - oStorage[4];
-    storage[5] = storage[5] - oStorage[5];
-    storage[6] = storage[6] - oStorage[6];
-    storage[7] = storage[7] - oStorage[7];
-    storage[8] = storage[8] - oStorage[8];
+  /// Subtract [other] from this.
+  void sub(Matrix3 other) {
+    this[0] -= other[0];
+    this[1] -= other[1];
+    this[2] -= other[2];
+    this[3] -= other[3];
+    this[4] -= other[4];
+    this[5] -= other[5];
+    this[6] -= other[6];
+    this[7] -= other[7];
+    this[8] -= other[8];
   }
 
   /// Negate this.
   void negate() {
-    storage[0] = -storage[0];
-    storage[1] = -storage[1];
-    storage[2] = -storage[2];
-    storage[3] = -storage[3];
-    storage[4] = -storage[4];
-    storage[5] = -storage[5];
-    storage[6] = -storage[6];
-    storage[7] = -storage[7];
-    storage[8] = -storage[8];
+    this[0] *= -1;
+    this[1] *= -1;
+    this[2] *= -1;
+    this[3] *= -1;
+    this[4] *= -1;
+    this[5] *= -1;
+    this[6] *= -1;
+    this[7] *= -1;
+    this[8] *= -1;
   }
 
-  /// Multiply this by [arg].
-  void multiply(Matrix3 arg) {
-    final m00 = storage[0];
-    final m01 = storage[3];
-    final m02 = storage[6];
-    final m10 = storage[1];
-    final m11 = storage[4];
-    final m12 = storage[7];
-    final m20 = storage[2];
-    final m21 = storage[5];
-    final m22 = storage[8];
-    final argStorage = arg.storage;
-    final n00 = argStorage[0];
-    final n01 = argStorage[3];
-    final n02 = argStorage[6];
-    final n10 = argStorage[1];
-    final n11 = argStorage[4];
-    final n12 = argStorage[7];
-    final n20 = argStorage[2];
-    final n21 = argStorage[5];
-    final n22 = argStorage[8];
-    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
-    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
-    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
-    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
-    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
-    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
-    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
-    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
-    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
+  /// Multiply this by [other].
+  void multiply(Matrix3 other) {
+    final m00 = this[0];
+    final m01 = this[3];
+    final m02 = this[6];
+    final m10 = this[1];
+    final m11 = this[4];
+    final m12 = this[7];
+    final m20 = this[2];
+    final m21 = this[5];
+    final m22 = this[8];
+    final n00 = other[0];
+    final n01 = other[3];
+    final n02 = other[6];
+    final n10 = other[1];
+    final n11 = other[4];
+    final n12 = other[7];
+    final n20 = other[2];
+    final n21 = other[5];
+    final n22 = other[8];
+    this[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    this[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    this[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    this[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    this[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    this[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    this[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    this[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    this[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
-  /// Create a copy of this and multiply it by [arg].
-  Matrix3 multiplied(Matrix3 arg) => clone()..multiply(arg);
+  /// Create a copy of this and multiply it by [other].
+  Matrix3 multiplied(Matrix3 other) => clone()..multiply(other);
 
-  void transposeMultiply(Matrix3 arg) {
-    final m00 = storage[0];
-    final m01 = storage[1];
-    final m02 = storage[2];
-    final m10 = storage[3];
-    final m11 = storage[4];
-    final m12 = storage[5];
-    final m20 = storage[6];
-    final m21 = storage[7];
-    final m22 = storage[8];
-    final argStorage = arg.storage;
-    storage[0] =
-        (m00 * argStorage[0]) + (m01 * argStorage[1]) + (m02 * argStorage[2]);
-    storage[3] =
-        (m00 * argStorage[3]) + (m01 * argStorage[4]) + (m02 * argStorage[5]);
-    storage[6] =
-        (m00 * argStorage[6]) + (m01 * argStorage[7]) + (m02 * argStorage[8]);
-    storage[1] =
-        (m10 * argStorage[0]) + (m11 * argStorage[1]) + (m12 * argStorage[2]);
-    storage[4] =
-        (m10 * argStorage[3]) + (m11 * argStorage[4]) + (m12 * argStorage[5]);
-    storage[7] =
-        (m10 * argStorage[6]) + (m11 * argStorage[7]) + (m12 * argStorage[8]);
-    storage[2] =
-        (m20 * argStorage[0]) + (m21 * argStorage[1]) + (m22 * argStorage[2]);
-    storage[5] =
-        (m20 * argStorage[3]) + (m21 * argStorage[4]) + (m22 * argStorage[5]);
-    storage[8] =
-        (m20 * argStorage[6]) + (m21 * argStorage[7]) + (m22 * argStorage[8]);
+  void transposeMultiply(Matrix3 other) {
+    final m00 = this[0];
+    final m01 = this[1];
+    final m02 = this[2];
+    final m10 = this[3];
+    final m11 = this[4];
+    final m12 = this[5];
+    final m20 = this[6];
+    final m21 = this[7];
+    final m22 = this[8];
+    final n00 = other[0];
+    final n01 = other[3];
+    final n02 = other[6];
+    final n10 = other[1];
+    final n11 = other[4];
+    final n12 = other[7];
+    final n20 = other[2];
+    final n21 = other[5];
+    final n22 = other[8];
+    this[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    this[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    this[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    this[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    this[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    this[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    this[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    this[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    this[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
-  void multiplyTranspose(Matrix3 arg) {
-    final m00 = storage[0];
-    final m01 = storage[3];
-    final m02 = storage[6];
-    final m10 = storage[1];
-    final m11 = storage[4];
-    final m12 = storage[7];
-    final m20 = storage[2];
-    final m21 = storage[5];
-    final m22 = storage[8];
-    final argStorage = arg.storage;
-    storage[0] =
-        (m00 * argStorage[0]) + (m01 * argStorage[3]) + (m02 * argStorage[6]);
-    storage[3] =
-        (m00 * argStorage[1]) + (m01 * argStorage[4]) + (m02 * argStorage[7]);
-    storage[6] =
-        (m00 * argStorage[2]) + (m01 * argStorage[5]) + (m02 * argStorage[8]);
-    storage[1] =
-        (m10 * argStorage[0]) + (m11 * argStorage[3]) + (m12 * argStorage[6]);
-    storage[4] =
-        (m10 * argStorage[1]) + (m11 * argStorage[4]) + (m12 * argStorage[7]);
-    storage[7] =
-        (m10 * argStorage[2]) + (m11 * argStorage[5]) + (m12 * argStorage[8]);
-    storage[2] =
-        (m20 * argStorage[0]) + (m21 * argStorage[3]) + (m22 * argStorage[6]);
-    storage[5] =
-        (m20 * argStorage[1]) + (m21 * argStorage[4]) + (m22 * argStorage[7]);
-    storage[8] =
-        (m20 * argStorage[2]) + (m21 * argStorage[5]) + (m22 * argStorage[8]);
+  void multiplyTranspose(Matrix3 other) {
+    final m00 = this[0];
+    final m01 = this[3];
+    final m02 = this[6];
+    final m10 = this[1];
+    final m11 = this[4];
+    final m12 = this[7];
+    final m20 = this[2];
+    final m21 = this[5];
+    final m22 = this[8];
+    final n00 = other[0];
+    final n01 = other[3];
+    final n02 = other[6];
+    final n10 = other[1];
+    final n11 = other[4];
+    final n12 = other[7];
+    final n20 = other[2];
+    final n21 = other[5];
+    final n22 = other[8];
+    this[0] = (m00 * n00) + (m01 * n01) + (m02 * n02);
+    this[3] = (m00 * n10) + (m01 * n11) + (m02 * n12);
+    this[6] = (m00 * n20) + (m01 * n21) + (m02 * n22);
+    this[1] = (m10 * n00) + (m11 * n01) + (m12 * n02);
+    this[4] = (m10 * n10) + (m11 * n11) + (m12 * n12);
+    this[7] = (m10 * n20) + (m11 * n21) + (m12 * n22);
+    this[2] = (m20 * n00) + (m21 * n01) + (m22 * n02);
+    this[5] = (m20 * n10) + (m21 * n11) + (m22 * n12);
+    this[8] = (m20 * n20) + (m21 * n21) + (m22 * n22);
   }
 
   /// Transform [arg] of type [Vector3] using the transformation defined by
   /// this.
-  Vector3 transform(Vector3 arg) {
-    final argStorage = arg._v3storage;
-    final x_ = (storage[0] * argStorage[0]) +
-        (storage[3] * argStorage[1]) +
-        (storage[6] * argStorage[2]);
-    final y_ = (storage[1] * argStorage[0]) +
-        (storage[4] * argStorage[1]) +
-        (storage[7] * argStorage[2]);
-    final z_ = (storage[2] * argStorage[0]) +
-        (storage[5] * argStorage[1]) +
-        (storage[8] * argStorage[2]);
-    arg
-      ..x = x_
-      ..y = y_
-      ..z = z_;
-    return arg;
-  }
+  Vector3 transform(Vector3 arg) => arg
+    ..setValues(
+      (this[0] * arg[0]) + (this[3] * arg[1]) + (this[6] * arg[2]),
+      (this[1] * arg[0]) + (this[4] * arg[1]) + (this[7] * arg[2]),
+      (this[2] * arg[0]) + (this[5] * arg[1]) + (this[8] * arg[2]),
+    );
 
   /// Transform a copy of [arg] of type [Vector3] using the transformation
   /// defined by this. If a [out] parameter is supplied, the copy is stored in
   /// [out].
   Vector3 transformed(Vector3 arg, [Vector3? out]) {
-    if (out == null) {
-      out = Vector3.copy(arg);
-    } else {
-      out.setFrom(arg);
-    }
-    return transform(out);
+    final outLocal = (out?..setFrom(arg)) ?? arg.clone();
+    return transform(outLocal);
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<num> array, [int offset = 0]) {
-    final i = offset;
-    array[i + 8] = storage[8];
-    array[i + 7] = storage[7];
-    array[i + 6] = storage[6];
-    array[i + 5] = storage[5];
-    array[i + 4] = storage[4];
-    array[i + 3] = storage[3];
-    array[i + 2] = storage[2];
-    array[i + 1] = storage[1];
-    array[i + 0] = storage[0];
+    array[offset + 0] = this[0];
+    array[offset + 1] = this[1];
+    array[offset + 2] = this[2];
+    array[offset + 3] = this[3];
+    array[offset + 4] = this[4];
+    array[offset + 5] = this[5];
+    array[offset + 6] = this[6];
+    array[offset + 7] = this[7];
+    array[offset + 8] = this[8];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    final i = offset;
-    storage[8] = array[i + 8];
-    storage[7] = array[i + 7];
-    storage[6] = array[i + 6];
-    storage[5] = array[i + 5];
-    storage[4] = array[i + 4];
-    storage[3] = array[i + 3];
-    storage[2] = array[i + 2];
-    storage[1] = array[i + 1];
-    storage[0] = array[i + 0];
+    this[0] = array[offset + 0];
+    this[1] = array[offset + 1];
+    this[2] = array[offset + 2];
+    this[3] = array[offset + 3];
+    this[4] = array[offset + 4];
+    this[5] = array[offset + 5];
+    this[6] = array[offset + 6];
+    this[7] = array[offset + 7];
+    this[8] = array[offset + 8];
   }
 
   /// Multiply this to each set of xyz values in [array] starting at [offset].
   List<double> applyToVector3Array(List<double> array, [int offset = 0]) {
     for (var i = 0, j = offset; i < array.length; i += 3, j += 3) {
       final v = Vector3.array(array, j)..applyMatrix3(this);
-      array[j] = v.storage[0];
-      array[j + 1] = v.storage[1];
-      array[j + 2] = v.storage[2];
+      array[j] = v[0];
+      array[j + 1] = v[1];
+      array[j + 2] = v[2];
     }
 
     return array;
   }
 
-  Vector3 get right {
-    final x = storage[0];
-    final y = storage[1];
-    final z = storage[2];
-    return Vector3(x, y, z);
-  }
+  Vector3 get right => Vector3(this[0], this[1], this[2]);
 
-  Vector3 get up {
-    final x = storage[3];
-    final y = storage[4];
-    final z = storage[5];
-    return Vector3(x, y, z);
-  }
+  Vector3 get up => Vector3(this[3], this[4], this[5]);
 
-  Vector3 get forward {
-    final x = storage[6];
-    final y = storage[7];
-    final z = storage[8];
-    return Vector3(x, y, z);
-  }
+  Vector3 get forward => Vector3(this[6], this[7], this[8]);
 
   /// Is this the identity matrix?
   bool isIdentity() =>
-      storage[0] == 1.0 // col 1
+      this[0] == 1.0 // col 1
       &&
-      storage[1] == 0.0 &&
-      storage[2] == 0.0 &&
-      storage[3] == 0.0 // col 2
+      this[1] == 0.0 &&
+      this[2] == 0.0 &&
+      this[3] == 0.0 // col 2
       &&
-      storage[4] == 1.0 &&
-      storage[5] == 0.0 &&
-      storage[6] == 0.0 // col 3
+      this[4] == 1.0 &&
+      this[5] == 0.0 &&
+      this[6] == 0.0 // col 3
       &&
-      storage[7] == 0.0 &&
-      storage[8] == 1.0;
+      this[7] == 0.0 &&
+      this[8] == 1.0;
 
   /// Is this the zero matrix?
   bool isZero() =>
-      storage[0] == 0.0 // col 1
+      this[0] == 0.0 // col 1
       &&
-      storage[1] == 0.0 &&
-      storage[2] == 0.0 &&
-      storage[3] == 0.0 // col 2
+      this[1] == 0.0 &&
+      this[2] == 0.0 &&
+      this[3] == 0.0 // col 2
       &&
-      storage[4] == 0.0 &&
-      storage[5] == 0.0 &&
-      storage[6] == 0.0 // col 3
+      this[4] == 0.0 &&
+      this[5] == 0.0 &&
+      this[6] == 0.0 // col 3
       &&
-      storage[7] == 0.0 &&
-      storage[8] == 0.0;
+      this[7] == 0.0 &&
+      this[8] == 0.0;
 }

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -162,7 +162,7 @@ class Matrix3 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    return this[index(row, col)];
+    return storage[index(row, col)];
   }
 
   /// Set value at [row], [col] to be [v].
@@ -170,82 +170,82 @@ class Matrix3 {
     assert((row >= 0) && (row < dimension));
     assert((col >= 0) && (col < dimension));
 
-    this[index(row, col)] = v;
+    storage[index(row, col)] = v;
   }
 
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
-    this[0] = arg0;
-    this[1] = arg1;
-    this[2] = arg2;
-    this[3] = arg3;
-    this[4] = arg4;
-    this[5] = arg5;
-    this[6] = arg6;
-    this[7] = arg7;
-    this[8] = arg8;
+    storage[0] = arg0;
+    storage[1] = arg1;
+    storage[2] = arg2;
+    storage[3] = arg3;
+    storage[4] = arg4;
+    storage[5] = arg5;
+    storage[6] = arg6;
+    storage[7] = arg7;
+    storage[8] = arg8;
   }
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
-    this[0] = arg0[0];
-    this[1] = arg0[1];
-    this[2] = arg0[2];
-    this[3] = arg1[0];
-    this[4] = arg1[1];
-    this[5] = arg1[2];
-    this[6] = arg2[0];
-    this[7] = arg2[1];
-    this[8] = arg2[2];
+    storage[0] = arg0[0];
+    storage[1] = arg0[1];
+    storage[2] = arg0[2];
+    storage[3] = arg1[0];
+    storage[4] = arg1[1];
+    storage[5] = arg1[2];
+    storage[6] = arg2[0];
+    storage[7] = arg2[1];
+    storage[8] = arg2[2];
   }
 
   /// Sets the entire matrix to the matrix in [other].
   void setFrom(Matrix3 other) {
-    this[0] = other[0];
-    this[1] = other[1];
-    this[2] = other[2];
-    this[3] = other[3];
-    this[4] = other[4];
-    this[5] = other[5];
-    this[6] = other[6];
-    this[7] = other[7];
-    this[8] = other[8];
+    storage[0] = other.storage[0];
+    storage[1] = other.storage[1];
+    storage[2] = other.storage[2];
+    storage[3] = other.storage[3];
+    storage[4] = other.storage[4];
+    storage[5] = other.storage[5];
+    storage[6] = other.storage[6];
+    storage[7] = other.storage[7];
+    storage[8] = other.storage[8];
   }
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector3 u, Vector3 v) {
-    this[0] = u[0] * v[0];
-    this[1] = u[0] * v[1];
-    this[2] = u[0] * v[2];
-    this[3] = u[1] * v[0];
-    this[4] = u[1] * v[1];
-    this[5] = u[1] * v[2];
-    this[6] = u[2] * v[0];
-    this[7] = u[2] * v[1];
-    this[8] = u[2] * v[2];
+    storage[0] = u[0] * v[0];
+    storage[1] = u[0] * v[1];
+    storage[2] = u[0] * v[2];
+    storage[3] = u[1] * v[0];
+    storage[4] = u[1] * v[1];
+    storage[5] = u[1] * v[2];
+    storage[6] = u[2] * v[0];
+    storage[7] = u[2] * v[1];
+    storage[8] = u[2] * v[2];
   }
 
   /// Set the diagonal of the matrix.
   void splatDiagonal(double arg) {
-    this[0] = arg;
-    this[4] = arg;
-    this[8] = arg;
+    storage[0] = arg;
+    storage[4] = arg;
+    storage[8] = arg;
   }
 
   /// Set the diagonal of the matrix.
   void setDiagonal(Vector3 arg) {
-    this[0] = arg[0];
-    this[4] = arg[1];
-    this[8] = arg[2];
+    storage[0] = arg[0];
+    storage[4] = arg[1];
+    storage[8] = arg[2];
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    this[0] = arg[0];
-    this[1] = arg[1];
-    this[3] = arg[2];
-    this[4] = arg[3];
+    storage[0] = arg[0];
+    storage[1] = arg[1];
+    storage[3] = arg[2];
+    storage[4] = arg[3];
   }
 
   /// Returns a printable string
@@ -267,15 +267,15 @@ class Matrix3 {
   @override
   bool operator ==(Object other) =>
       (other is Matrix3) &&
-      (this[0] == other[0]) &&
-      (this[1] == other[1]) &&
-      (this[2] == other[2]) &&
-      (this[3] == other[3]) &&
-      (this[4] == other[4]) &&
-      (this[5] == other[5]) &&
-      (this[6] == other[6]) &&
-      (this[7] == other[7]) &&
-      (this[8] == other[8]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]) &&
+      (storage[2] == other.storage[2]) &&
+      (storage[3] == other.storage[3]) &&
+      (storage[4] == other.storage[4]) &&
+      (storage[5] == other.storage[5]) &&
+      (storage[6] == other.storage[6]) &&
+      (storage[7] == other.storage[7]) &&
+      (storage[8] == other.storage[8]);
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -300,30 +300,30 @@ class Matrix3 {
 
   /// Assigns the [row] of to [arg].
   void setRow(int row, Vector3 arg) {
-    this[index(row, 0)] = arg[0];
-    this[index(row, 1)] = arg[1];
-    this[index(row, 2)] = arg[2];
+    storage[index(row, 0)] = arg[0];
+    storage[index(row, 1)] = arg[1];
+    storage[index(row, 2)] = arg[2];
   }
 
   /// Gets the [row] of the matrix
   Vector3 getRow(int row) => Vector3(
-        this[index(row, 0)],
-        this[index(row, 1)],
-        this[index(row, 2)],
+        storage[index(row, 0)],
+        storage[index(row, 1)],
+        storage[index(row, 2)],
       );
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector3 arg) {
     final entry = column * 3;
-    this[entry + 2] = arg[2];
-    this[entry + 1] = arg[1];
-    this[entry + 0] = arg[0];
+    storage[entry + 2] = arg[2];
+    storage[entry + 1] = arg[1];
+    storage[entry + 0] = arg[0];
   }
 
   /// Gets the [column] of the matrix
   Vector3 getColumn(int column) {
     final entry = column * 3;
-    return Vector3(this[entry + 0], this[entry + 1], this[entry + 2]);
+    return Vector3(storage[entry + 0], storage[entry + 1], storage[entry + 2]);
   }
 
   /// Clone of this.
@@ -357,28 +357,28 @@ class Matrix3 {
 
   /// Zeros this.
   void setZero() {
-    this[0] = 0.0;
-    this[1] = 0.0;
-    this[2] = 0.0;
-    this[3] = 0.0;
-    this[4] = 0.0;
-    this[5] = 0.0;
-    this[6] = 0.0;
-    this[7] = 0.0;
-    this[8] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 0.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 0.0;
   }
 
   /// Makes this into the identity matrix.
   void setIdentity() {
-    this[0] = 1.0;
-    this[1] = 0.0;
-    this[2] = 0.0;
-    this[3] = 0.0;
-    this[4] = 1.0;
-    this[5] = 0.0;
-    this[6] = 0.0;
-    this[7] = 0.0;
-    this[8] = 1.0;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Returns the tranpose of this.
@@ -387,61 +387,66 @@ class Matrix3 {
   /// Transpose this.
   void transpose() {
     double temp;
-    temp = this[3];
-    this[3] = this[1];
-    this[1] = temp;
-    temp = this[6];
-    this[6] = this[2];
-    this[2] = temp;
-    temp = this[7];
-    this[7] = this[5];
-    this[5] = temp;
+    temp = storage[3];
+    storage[3] = storage[1];
+    storage[1] = temp;
+    temp = storage[6];
+    storage[6] = storage[2];
+    storage[2] = temp;
+    temp = storage[7];
+    storage[7] = storage[5];
+    storage[5] = temp;
   }
 
   /// Returns the component wise absolute value of this.
   Matrix3 absolute() => Matrix3(
-        this[0].abs(),
-        this[1].abs(),
-        this[2].abs(),
-        this[3].abs(),
-        this[4].abs(),
-        this[5].abs(),
-        this[6].abs(),
-        this[7].abs(),
-        this[8].abs(),
+        storage[0].abs(),
+        storage[1].abs(),
+        storage[2].abs(),
+        storage[3].abs(),
+        storage[4].abs(),
+        storage[5].abs(),
+        storage[6].abs(),
+        storage[7].abs(),
+        storage[8].abs(),
       );
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    final x = this[0] * ((this[4] * this[8]) - (this[5] * this[7]));
-    final y = this[1] * ((this[3] * this[8]) - (this[5] * this[6]));
-    final z = this[2] * ((this[3] * this[7]) - (this[4] * this[6]));
+    final x =
+        storage[0] * ((storage[4] * storage[8]) - (storage[5] * storage[7]));
+    final y =
+        storage[1] * ((storage[3] * storage[8]) - (storage[5] * storage[6]));
+    final z =
+        storage[2] * ((storage[3] * storage[7]) - (storage[4] * storage[6]));
     return x - y + z;
   }
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector3 v) =>
-      this[i] * v[0] + this[3 + i] * v[1] + this[6 + i] * v[2];
+      storage[i] * v[0] + storage[3 + i] * v[1] + storage[6 + i] * v[2];
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector3 v) =>
-      this[j * 3] * v[0] + this[j * 3 + 1] * v[1] + this[j * 3 + 2] * v[2];
+      storage[j * 3] * v[0] +
+      storage[j * 3 + 1] * v[1] +
+      storage[j * 3 + 2] * v[2];
 
   /// Returns the trace of the matrix. The trace of a matrix is the sum of
   /// the diagonal entries.
   double trace() {
     var t = 0.0;
-    t += this[0];
-    t += this[4];
-    t += this[8];
+    t += storage[0];
+    t += storage[4];
+    t += storage[8];
     return t;
   }
 
   /// Returns infinity norm of the matrix. Used for numerical analysis.
   double infinityNorm() {
-    final row1 = this[0].abs() + this[1].abs() + this[2].abs();
-    final row2 = this[3].abs() + this[4].abs() + this[5].abs();
-    final row3 = this[6].abs() + this[7].abs() + this[8].abs();
+    final row1 = storage[0].abs() + storage[1].abs() + storage[2].abs();
+    final row2 = storage[3].abs() + storage[4].abs() + storage[5].abs();
+    final row3 = storage[6].abs() + storage[7].abs() + storage[8].abs();
     return math.max(row1, math.max(row2, math.max(row3, 0)));
   }
 
@@ -472,24 +477,42 @@ class Matrix3 {
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final ix = invDet * (other[4] * other[8] - other[5] * other[7]);
-    final iy = invDet * (other[2] * other[7] - other[1] * other[8]);
-    final iz = invDet * (other[1] * other[5] - other[2] * other[4]);
-    final jx = invDet * (other[5] * other[6] - other[3] * other[8]);
-    final jy = invDet * (other[0] * other[8] - other[2] * other[6]);
-    final jz = invDet * (other[2] * other[3] - other[0] * other[5]);
-    final kx = invDet * (other[3] * other[7] - other[4] * other[6]);
-    final ky = invDet * (other[1] * other[6] - other[0] * other[7]);
-    final kz = invDet * (other[0] * other[4] - other[1] * other[3]);
-    this[0] = ix;
-    this[1] = iy;
-    this[2] = iz;
-    this[3] = jx;
-    this[4] = jy;
-    this[5] = jz;
-    this[6] = kx;
-    this[7] = ky;
-    this[8] = kz;
+    final ix = invDet *
+        (other.storage[4] * other.storage[8] -
+            other.storage[5] * other.storage[7]);
+    final iy = invDet *
+        (other.storage[2] * other.storage[7] -
+            other.storage[1] * other.storage[8]);
+    final iz = invDet *
+        (other.storage[1] * other.storage[5] -
+            other.storage[2] * other.storage[4]);
+    final jx = invDet *
+        (other.storage[5] * other.storage[6] -
+            other.storage[3] * other.storage[8]);
+    final jy = invDet *
+        (other.storage[0] * other.storage[8] -
+            other.storage[2] * other.storage[6]);
+    final jz = invDet *
+        (other.storage[2] * other.storage[3] -
+            other.storage[0] * other.storage[5]);
+    final kx = invDet *
+        (other.storage[3] * other.storage[7] -
+            other.storage[4] * other.storage[6]);
+    final ky = invDet *
+        (other.storage[1] * other.storage[6] -
+            other.storage[0] * other.storage[7]);
+    final kz = invDet *
+        (other.storage[0] * other.storage[4] -
+            other.storage[1] * other.storage[3]);
+    storage[0] = ix;
+    storage[1] = iy;
+    storage[2] = iz;
+    storage[3] = jx;
+    storage[4] = jy;
+    storage[5] = jz;
+    storage[6] = kx;
+    storage[7] = ky;
+    storage[8] = kz;
     return det;
   }
 
@@ -503,82 +526,82 @@ class Matrix3 {
   void setRotationX(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    this[0] = 1.0;
-    this[1] = 0.0;
-    this[2] = 0.0;
-    this[3] = 0.0;
-    this[4] = c;
-    this[5] = s;
-    this[6] = 0.0;
-    this[7] = -s;
-    this[8] = c;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = c;
+    storage[5] = s;
+    storage[6] = 0.0;
+    storage[7] = -s;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Y
   void setRotationY(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    this[0] = c;
-    this[1] = 0.0;
-    this[2] = s;
-    this[3] = 0.0;
-    this[4] = 1.0;
-    this[5] = 0.0;
-    this[6] = -s;
-    this[7] = 0.0;
-    this[8] = c;
+    storage[0] = c;
+    storage[1] = 0.0;
+    storage[2] = s;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = -s;
+    storage[7] = 0.0;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Z
   void setRotationZ(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    this[0] = c;
-    this[1] = s;
-    this[2] = 0.0;
-    this[3] = -s;
-    this[4] = c;
-    this[5] = 0.0;
-    this[6] = 0.0;
-    this[7] = 0.0;
-    this[8] = 1.0;
+    storage[0] = c;
+    storage[1] = s;
+    storage[2] = 0.0;
+    storage[3] = -s;
+    storage[4] = c;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
   void scaleAdjoint(double scale) {
-    final m00 = this[0];
-    final m01 = this[3];
-    final m02 = this[6];
-    final m10 = this[1];
-    final m11 = this[4];
-    final m12 = this[7];
-    final m20 = this[2];
-    final m21 = this[5];
-    final m22 = this[8];
-    this[0] = (m11 * m22 - m12 * m21) * scale;
-    this[1] = (m12 * m20 - m10 * m22) * scale;
-    this[2] = (m10 * m21 - m11 * m20) * scale;
-    this[3] = (m02 * m21 - m01 * m22) * scale;
-    this[4] = (m00 * m22 - m02 * m20) * scale;
-    this[5] = (m01 * m20 - m00 * m21) * scale;
-    this[6] = (m01 * m12 - m02 * m11) * scale;
-    this[7] = (m02 * m10 - m00 * m12) * scale;
-    this[8] = (m00 * m11 - m01 * m10) * scale;
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    storage[0] = (m11 * m22 - m12 * m21) * scale;
+    storage[1] = (m12 * m20 - m10 * m22) * scale;
+    storage[2] = (m10 * m21 - m11 * m20) * scale;
+    storage[3] = (m02 * m21 - m01 * m22) * scale;
+    storage[4] = (m00 * m22 - m02 * m20) * scale;
+    storage[5] = (m01 * m20 - m00 * m21) * scale;
+    storage[6] = (m01 * m12 - m02 * m11) * scale;
+    storage[7] = (m02 * m10 - m00 * m12) * scale;
+    storage[8] = (m00 * m11 - m01 * m10) * scale;
   }
 
   /// Rotates [arg] by the absolute rotation of this
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector3 absoluteRotate(Vector3 arg) {
-    final m00 = this[0].abs();
-    final m01 = this[3].abs();
-    final m02 = this[6].abs();
-    final m10 = this[1].abs();
-    final m11 = this[4].abs();
-    final m12 = this[7].abs();
-    final m20 = this[2].abs();
-    final m21 = this[5].abs();
-    final m22 = this[8].abs();
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m02 = storage[6].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
+    final m12 = storage[7].abs();
+    final m20 = storage[2].abs();
+    final m21 = storage[5].abs();
+    final m22 = storage[8].abs();
     final x = arg[0];
     final y = arg[1];
     final z = arg[2];
@@ -592,10 +615,10 @@ class Matrix3 {
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector2 absoluteRotate2(Vector2 arg) {
-    final m00 = this[0].abs();
-    final m01 = this[3].abs();
-    final m10 = this[1].abs();
-    final m11 = this[4].abs();
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
     final x = arg[0];
     final y = arg[1];
     arg[0] = x * m00 + y * m01;
@@ -606,21 +629,21 @@ class Matrix3 {
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) => arg
     ..setValues(
-      (this[0] * arg[0]) + (this[3] * arg[1]) + this[6],
-      (this[1] * arg[0]) + (this[4] * arg[1]) + this[7],
+      (storage[0] * arg[0]) + (storage[3] * arg[1]) + storage[6],
+      (storage[1] * arg[0]) + (storage[4] * arg[1]) + storage[7],
     );
 
   /// Scales this by [scale].
   void scale(double scale) {
-    this[0] *= scale;
-    this[1] *= scale;
-    this[2] *= scale;
-    this[3] *= scale;
-    this[4] *= scale;
-    this[5] *= scale;
-    this[6] *= scale;
-    this[7] *= scale;
-    this[8] *= scale;
+    storage[0] *= scale;
+    storage[1] *= scale;
+    storage[2] *= scale;
+    storage[3] *= scale;
+    storage[4] *= scale;
+    storage[5] *= scale;
+    storage[6] *= scale;
+    storage[7] *= scale;
+    storage[8] *= scale;
   }
 
   /// Create a copy of this and scale it by [scale].
@@ -628,144 +651,144 @@ class Matrix3 {
 
   /// Add [other] to this.
   void add(Matrix3 other) {
-    this[0] += other[0];
-    this[1] += other[1];
-    this[2] += other[2];
-    this[3] += other[3];
-    this[4] += other[4];
-    this[5] += other[5];
-    this[6] += other[6];
-    this[7] += other[7];
-    this[8] += other[8];
+    storage[0] += other.storage[0];
+    storage[1] += other.storage[1];
+    storage[2] += other.storage[2];
+    storage[3] += other.storage[3];
+    storage[4] += other.storage[4];
+    storage[5] += other.storage[5];
+    storage[6] += other.storage[6];
+    storage[7] += other.storage[7];
+    storage[8] += other.storage[8];
   }
 
   /// Subtract [other] from this.
   void sub(Matrix3 other) {
-    this[0] -= other[0];
-    this[1] -= other[1];
-    this[2] -= other[2];
-    this[3] -= other[3];
-    this[4] -= other[4];
-    this[5] -= other[5];
-    this[6] -= other[6];
-    this[7] -= other[7];
-    this[8] -= other[8];
+    storage[0] -= other.storage[0];
+    storage[1] -= other.storage[1];
+    storage[2] -= other.storage[2];
+    storage[3] -= other.storage[3];
+    storage[4] -= other.storage[4];
+    storage[5] -= other.storage[5];
+    storage[6] -= other.storage[6];
+    storage[7] -= other.storage[7];
+    storage[8] -= other.storage[8];
   }
 
   /// Negate this.
   void negate() {
-    this[0] *= -1;
-    this[1] *= -1;
-    this[2] *= -1;
-    this[3] *= -1;
-    this[4] *= -1;
-    this[5] *= -1;
-    this[6] *= -1;
-    this[7] *= -1;
-    this[8] *= -1;
+    storage[0] *= -1;
+    storage[1] *= -1;
+    storage[2] *= -1;
+    storage[3] *= -1;
+    storage[4] *= -1;
+    storage[5] *= -1;
+    storage[6] *= -1;
+    storage[7] *= -1;
+    storage[8] *= -1;
   }
 
   /// Multiply this by [other].
   void multiply(Matrix3 other) {
-    final m00 = this[0];
-    final m01 = this[3];
-    final m02 = this[6];
-    final m10 = this[1];
-    final m11 = this[4];
-    final m12 = this[7];
-    final m20 = this[2];
-    final m21 = this[5];
-    final m22 = this[8];
-    final n00 = other[0];
-    final n01 = other[3];
-    final n02 = other[6];
-    final n10 = other[1];
-    final n11 = other[4];
-    final n12 = other[7];
-    final n20 = other[2];
-    final n21 = other[5];
-    final n22 = other[8];
-    this[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
-    this[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
-    this[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
-    this[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
-    this[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
-    this[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
-    this[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
-    this[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
-    this[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
   /// Create a copy of this and multiply it by [other].
   Matrix3 multiplied(Matrix3 other) => clone()..multiply(other);
 
   void transposeMultiply(Matrix3 other) {
-    final m00 = this[0];
-    final m01 = this[1];
-    final m02 = this[2];
-    final m10 = this[3];
-    final m11 = this[4];
-    final m12 = this[5];
-    final m20 = this[6];
-    final m21 = this[7];
-    final m22 = this[8];
-    final n00 = other[0];
-    final n01 = other[3];
-    final n02 = other[6];
-    final n10 = other[1];
-    final n11 = other[4];
-    final n12 = other[7];
-    final n20 = other[2];
-    final n21 = other[5];
-    final n22 = other[8];
-    this[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
-    this[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
-    this[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
-    this[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
-    this[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
-    this[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
-    this[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
-    this[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
-    this[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
+    final m00 = storage[0];
+    final m01 = storage[1];
+    final m02 = storage[2];
+    final m10 = storage[3];
+    final m11 = storage[4];
+    final m12 = storage[5];
+    final m20 = storage[6];
+    final m21 = storage[7];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
   void multiplyTranspose(Matrix3 other) {
-    final m00 = this[0];
-    final m01 = this[3];
-    final m02 = this[6];
-    final m10 = this[1];
-    final m11 = this[4];
-    final m12 = this[7];
-    final m20 = this[2];
-    final m21 = this[5];
-    final m22 = this[8];
-    final n00 = other[0];
-    final n01 = other[3];
-    final n02 = other[6];
-    final n10 = other[1];
-    final n11 = other[4];
-    final n12 = other[7];
-    final n20 = other[2];
-    final n21 = other[5];
-    final n22 = other[8];
-    this[0] = (m00 * n00) + (m01 * n01) + (m02 * n02);
-    this[3] = (m00 * n10) + (m01 * n11) + (m02 * n12);
-    this[6] = (m00 * n20) + (m01 * n21) + (m02 * n22);
-    this[1] = (m10 * n00) + (m11 * n01) + (m12 * n02);
-    this[4] = (m10 * n10) + (m11 * n11) + (m12 * n12);
-    this[7] = (m10 * n20) + (m11 * n21) + (m12 * n22);
-    this[2] = (m20 * n00) + (m21 * n01) + (m22 * n02);
-    this[5] = (m20 * n10) + (m21 * n11) + (m22 * n12);
-    this[8] = (m20 * n20) + (m21 * n21) + (m22 * n22);
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n01) + (m02 * n02);
+    storage[3] = (m00 * n10) + (m01 * n11) + (m02 * n12);
+    storage[6] = (m00 * n20) + (m01 * n21) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n01) + (m12 * n02);
+    storage[4] = (m10 * n10) + (m11 * n11) + (m12 * n12);
+    storage[7] = (m10 * n20) + (m11 * n21) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n01) + (m22 * n02);
+    storage[5] = (m20 * n10) + (m21 * n11) + (m22 * n12);
+    storage[8] = (m20 * n20) + (m21 * n21) + (m22 * n22);
   }
 
   /// Transform [arg] of type [Vector3] using the transformation defined by
   /// this.
   Vector3 transform(Vector3 arg) => arg
     ..setValues(
-      (this[0] * arg[0]) + (this[3] * arg[1]) + (this[6] * arg[2]),
-      (this[1] * arg[0]) + (this[4] * arg[1]) + (this[7] * arg[2]),
-      (this[2] * arg[0]) + (this[5] * arg[1]) + (this[8] * arg[2]),
+      (storage[0] * arg[0]) + (storage[3] * arg[1]) + (storage[6] * arg[2]),
+      (storage[1] * arg[0]) + (storage[4] * arg[1]) + (storage[7] * arg[2]),
+      (storage[2] * arg[0]) + (storage[5] * arg[1]) + (storage[8] * arg[2]),
     );
 
   /// Transform a copy of [arg] of type [Vector3] using the transformation
@@ -778,28 +801,28 @@ class Matrix3 {
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<num> array, [int offset = 0]) {
-    array[offset + 0] = this[0];
-    array[offset + 1] = this[1];
-    array[offset + 2] = this[2];
-    array[offset + 3] = this[3];
-    array[offset + 4] = this[4];
-    array[offset + 5] = this[5];
-    array[offset + 6] = this[6];
-    array[offset + 7] = this[7];
-    array[offset + 8] = this[8];
+    array[offset + 0] = storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 2] = storage[2];
+    array[offset + 3] = storage[3];
+    array[offset + 4] = storage[4];
+    array[offset + 5] = storage[5];
+    array[offset + 6] = storage[6];
+    array[offset + 7] = storage[7];
+    array[offset + 8] = storage[8];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    this[0] = array[offset + 0];
-    this[1] = array[offset + 1];
-    this[2] = array[offset + 2];
-    this[3] = array[offset + 3];
-    this[4] = array[offset + 4];
-    this[5] = array[offset + 5];
-    this[6] = array[offset + 6];
-    this[7] = array[offset + 7];
-    this[8] = array[offset + 8];
+    storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[2] = array[offset + 2];
+    storage[3] = array[offset + 3];
+    storage[4] = array[offset + 4];
+    storage[5] = array[offset + 5];
+    storage[6] = array[offset + 6];
+    storage[7] = array[offset + 7];
+    storage[8] = array[offset + 8];
   }
 
   /// Multiply this to each set of xyz values in [array] starting at [offset].
@@ -814,39 +837,39 @@ class Matrix3 {
     return array;
   }
 
-  Vector3 get right => Vector3(this[0], this[1], this[2]);
+  Vector3 get right => Vector3(storage[0], storage[1], storage[2]);
 
-  Vector3 get up => Vector3(this[3], this[4], this[5]);
+  Vector3 get up => Vector3(storage[3], storage[4], storage[5]);
 
-  Vector3 get forward => Vector3(this[6], this[7], this[8]);
+  Vector3 get forward => Vector3(storage[6], storage[7], storage[8]);
 
   /// Is this the identity matrix?
   bool isIdentity() =>
-      this[0] == 1.0 // col 1
+      storage[0] == 1.0 // col 1
       &&
-      this[1] == 0.0 &&
-      this[2] == 0.0 &&
-      this[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      this[4] == 1.0 &&
-      this[5] == 0.0 &&
-      this[6] == 0.0 // col 3
+      storage[4] == 1.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      this[7] == 0.0 &&
-      this[8] == 1.0;
+      storage[7] == 0.0 &&
+      storage[8] == 1.0;
 
   /// Is this the zero matrix?
   bool isZero() =>
-      this[0] == 0.0 // col 1
+      storage[0] == 0.0 // col 1
       &&
-      this[1] == 0.0 &&
-      this[2] == 0.0 &&
-      this[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      this[4] == 0.0 &&
-      this[5] == 0.0 &&
-      this[6] == 0.0 // col 3
+      storage[4] == 0.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      this[7] == 0.0 &&
-      this[8] == 0.0;
+      storage[7] == 0.0 &&
+      storage[8] == 0.0;
 }

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -466,11 +466,10 @@ class Matrix4 {
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    final argStorage = arg._m2storage;
-    _m4storage[0] = argStorage[0];
-    _m4storage[1] = argStorage[1];
-    _m4storage[4] = argStorage[2];
-    _m4storage[5] = argStorage[3];
+    _m4storage[0] = arg[0];
+    _m4storage[1] = arg[1];
+    _m4storage[4] = arg[2];
+    _m4storage[5] = arg[3];
   }
 
   /// Sets the diagonal of the matrix to be [arg].

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1146,28 +1146,28 @@ class Matrix4 {
   /// Copies the rotation matrix from this homogeneous transformation matrix
   /// into [rotation].
   void copyRotation(Matrix3 rotation) {
-    rotation[0] = _m4storage[0];
-    rotation[1] = _m4storage[1];
-    rotation[2] = _m4storage[2];
-    rotation[3] = _m4storage[4];
-    rotation[4] = _m4storage[5];
-    rotation[5] = _m4storage[6];
-    rotation[6] = _m4storage[8];
-    rotation[7] = _m4storage[9];
-    rotation[8] = _m4storage[10];
+    rotation.storage[0] = _m4storage[0];
+    rotation.storage[1] = _m4storage[1];
+    rotation.storage[2] = _m4storage[2];
+    rotation.storage[3] = _m4storage[4];
+    rotation.storage[4] = _m4storage[5];
+    rotation.storage[5] = _m4storage[6];
+    rotation.storage[6] = _m4storage[8];
+    rotation.storage[7] = _m4storage[9];
+    rotation.storage[8] = _m4storage[10];
   }
 
   /// Sets the rotation matrix in this homogeneous transformation matrix.
   void setRotation(Matrix3 rotation) {
-    _m4storage[0] = rotation[0];
-    _m4storage[1] = rotation[1];
-    _m4storage[2] = rotation[2];
-    _m4storage[4] = rotation[3];
-    _m4storage[5] = rotation[4];
-    _m4storage[6] = rotation[5];
-    _m4storage[8] = rotation[6];
-    _m4storage[9] = rotation[7];
-    _m4storage[10] = rotation[8];
+    _m4storage[0] = rotation.storage[0];
+    _m4storage[1] = rotation.storage[1];
+    _m4storage[2] = rotation.storage[2];
+    _m4storage[4] = rotation.storage[3];
+    _m4storage[5] = rotation.storage[4];
+    _m4storage[6] = rotation.storage[5];
+    _m4storage[8] = rotation.storage[6];
+    _m4storage[9] = rotation.storage[7];
+    _m4storage[10] = rotation.storage[8];
   }
 
   /// Returns the normal matrix from this homogeneous transformation matrix.

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -1146,30 +1146,28 @@ class Matrix4 {
   /// Copies the rotation matrix from this homogeneous transformation matrix
   /// into [rotation].
   void copyRotation(Matrix3 rotation) {
-    final rStorage = rotation._m3storage;
-    rStorage[0] = _m4storage[0];
-    rStorage[1] = _m4storage[1];
-    rStorage[2] = _m4storage[2];
-    rStorage[3] = _m4storage[4];
-    rStorage[4] = _m4storage[5];
-    rStorage[5] = _m4storage[6];
-    rStorage[6] = _m4storage[8];
-    rStorage[7] = _m4storage[9];
-    rStorage[8] = _m4storage[10];
+    rotation[0] = _m4storage[0];
+    rotation[1] = _m4storage[1];
+    rotation[2] = _m4storage[2];
+    rotation[3] = _m4storage[4];
+    rotation[4] = _m4storage[5];
+    rotation[5] = _m4storage[6];
+    rotation[6] = _m4storage[8];
+    rotation[7] = _m4storage[9];
+    rotation[8] = _m4storage[10];
   }
 
   /// Sets the rotation matrix in this homogeneous transformation matrix.
-  void setRotation(Matrix3 r) {
-    final rStorage = r._m3storage;
-    _m4storage[0] = rStorage[0];
-    _m4storage[1] = rStorage[1];
-    _m4storage[2] = rStorage[2];
-    _m4storage[4] = rStorage[3];
-    _m4storage[5] = rStorage[4];
-    _m4storage[6] = rStorage[5];
-    _m4storage[8] = rStorage[6];
-    _m4storage[9] = rStorage[7];
-    _m4storage[10] = rStorage[8];
+  void setRotation(Matrix3 rotation) {
+    _m4storage[0] = rotation[0];
+    _m4storage[1] = rotation[1];
+    _m4storage[2] = rotation[2];
+    _m4storage[4] = rotation[3];
+    _m4storage[5] = rotation[4];
+    _m4storage[6] = rotation[5];
+    _m4storage[8] = rotation[6];
+    _m4storage[9] = rotation[7];
+    _m4storage[10] = rotation[8];
   }
 
   /// Returns the normal matrix from this homogeneous transformation matrix.

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -68,36 +68,36 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    this[0] = x_;
-    this[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    this[0] = 0.0;
-    this[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    this[0] = other[0];
-    this[1] = other[1];
+    storage[0] = other[0];
+    storage[1] = other[1];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    this[0] = arg;
-    this[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${this[0]},${this[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      other is Vector2 && this[0] == other[0] && this[1] == other[1];
+      other is Vector2 && storage[0] == other[0] && storage[1] == other[1];
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -136,8 +136,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      this[0] *= l;
-      this[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -145,7 +145,7 @@ class Vector2 implements Vector {
   double get length => math.sqrt(length2);
 
   /// Length squared.
-  double get length2 => this[0] * this[0] + this[1] * this[1];
+  double get length2 => storage[0] * storage[0] + storage[1] * storage[1];
 
   /// Normalize this.
   double normalize() {
@@ -154,8 +154,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    this[0] *= d;
-    this[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -188,7 +188,7 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    if (this[0] == other[0] && this[1] == other[1]) {
+    if (storage[0] == other[0] && storage[1] == other[1]) {
       return 0.0;
     }
 
@@ -199,7 +199,7 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    if (this[0] == other[0] && this[1] == other[1]) {
+    if (storage[0] == other[0] && storage[1] == other[1]) {
       return 0.0;
     }
 
@@ -210,7 +210,7 @@ class Vector2 implements Vector {
   }
 
   /// Inner product.
-  double dot(Vector2 other) => this[0] * other[0] + this[1] * other[1];
+  double dot(Vector2 other) => storage[0] * other[0] + storage[1] * other[1];
 
   /// Transforms this into the product of this as a row vector,
   /// postmultiplied by matrix, [arg].
@@ -218,20 +218,20 @@ class Vector2 implements Vector {
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    final v0 = this[0];
-    final v1 = this[1];
-    this[0] = v0 * arg[0] + v1 * arg[1];
-    this[1] = v0 * arg[2] + v1 * arg[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * arg[0] + v1 * arg[1];
+    storage[1] = v0 * arg[2] + v1 * arg[3];
   }
 
   /// Cross product.
-  double cross(Vector2 other) => this[0] * other[1] - this[1] * other[0];
+  double cross(Vector2 other) => storage[0] * other[1] - storage[1] * other[0];
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * this[1], scale * this[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -251,45 +251,45 @@ class Vector2 implements Vector {
   double absoluteError(Vector2 correct) => (this - correct).length;
 
   /// True if any component is infinite.
-  bool get isInfinite => this[0].isInfinite || this[1].isInfinite;
+  bool get isInfinite => storage[0].isInfinite || storage[1].isInfinite;
 
   /// True if any component is NaN.
-  bool get isNaN => this[0].isNaN || this[1].isNaN;
+  bool get isNaN => storage[0].isNaN || storage[1].isNaN;
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    this[0] += arg[0];
-    this[1] += arg[1];
+    storage[0] += arg[0];
+    storage[1] += arg[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    this[0] += arg[0] * factor;
-    this[1] += arg[1] * factor;
+    storage[0] += arg[0] * factor;
+    storage[1] += arg[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    this[0] -= arg[0];
-    this[1] -= arg[1];
+    storage[0] -= arg[0];
+    storage[1] -= arg[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    this[0] *= arg[0];
-    this[1] *= arg[1];
+    storage[0] *= arg[0];
+    storage[1] *= arg[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    this[0] /= arg[0];
-    this[1] /= arg[1];
+    storage[0] /= arg[0];
+    storage[1] /= arg[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    this[0] *= arg;
-    this[1] *= arg;
+    storage[0] *= arg;
+    storage[1] *= arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -297,50 +297,54 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    this[0] *= -1;
-    this[1] *= -1;
+    storage[0] *= -1;
+    storage[1] *= -1;
   }
 
   /// Absolute value.
   void absolute() {
-    this[0] = this[0].abs();
-    this[1] = this[1].abs();
+    storage[0] = storage[0].abs();
+    storage[1] = storage[1].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
-    this[0] = this[0].clamp(min[0], max[0]).toDouble();
-    this[1] = this[1].clamp(min[1], max[1]).toDouble();
+    storage[0] = storage[0].clamp(min[0], max[0]).toDouble();
+    storage[1] = storage[1].clamp(min[1], max[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    this[0] = this[0].clamp(min, max).toDouble();
-    this[1] = this[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    this[0] = this[0].floorToDouble();
-    this[1] = this[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    this[0] = this[0].ceilToDouble();
-    this[1] = this[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    this[0] = this[0].roundToDouble();
-    this[1] = this[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    this[0] = this[0] < 0.0 ? this[0].ceilToDouble() : this[0].floorToDouble();
-    this[1] = this[1] < 0.0 ? this[1].ceilToDouble() : this[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -348,77 +352,77 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    arg[0] = this[0];
-    arg[1] = this[1];
+    arg[0] = storage[0];
+    arg[1] = storage[1];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 0] = this[0];
-    array[offset + 1] = this[1];
+    array[offset + 0] = storage[0];
+    array[offset + 1] = storage[1];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    this[0] = array[offset + 0];
-    this[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
   }
 
   set xy(Vector2 arg) {
-    this[0] = arg[0];
-    this[1] = arg[1];
+    storage[0] = arg[0];
+    storage[1] = arg[1];
   }
 
   set yx(Vector2 arg) {
-    this[0] = arg[1];
-    this[1] = arg[0];
+    storage[0] = arg[1];
+    storage[1] = arg[0];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => this[0] = arg;
-  set y(double arg) => this[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(this[0], this[0]);
-  Vector2 get xy => Vector2(this[0], this[1]);
-  Vector2 get yx => Vector2(this[1], this[0]);
-  Vector2 get yy => Vector2(this[1], this[1]);
-  Vector3 get xxx => Vector3(this[0], this[0], this[0]);
-  Vector3 get xxy => Vector3(this[0], this[0], this[1]);
-  Vector3 get xyx => Vector3(this[0], this[1], this[0]);
-  Vector3 get xyy => Vector3(this[0], this[1], this[1]);
-  Vector3 get yxx => Vector3(this[1], this[0], this[0]);
-  Vector3 get yxy => Vector3(this[1], this[0], this[1]);
-  Vector3 get yyx => Vector3(this[1], this[1], this[0]);
-  Vector3 get yyy => Vector3(this[1], this[1], this[1]);
-  Vector4 get xxxx => Vector4(this[0], this[0], this[0], this[0]);
-  Vector4 get xxxy => Vector4(this[0], this[0], this[0], this[1]);
-  Vector4 get xxyx => Vector4(this[0], this[0], this[1], this[0]);
-  Vector4 get xxyy => Vector4(this[0], this[0], this[1], this[1]);
-  Vector4 get xyxx => Vector4(this[0], this[1], this[0], this[0]);
-  Vector4 get xyxy => Vector4(this[0], this[1], this[0], this[1]);
-  Vector4 get xyyx => Vector4(this[0], this[1], this[1], this[0]);
-  Vector4 get xyyy => Vector4(this[0], this[1], this[1], this[1]);
-  Vector4 get yxxx => Vector4(this[1], this[0], this[0], this[0]);
-  Vector4 get yxxy => Vector4(this[1], this[0], this[0], this[1]);
-  Vector4 get yxyx => Vector4(this[1], this[0], this[1], this[0]);
-  Vector4 get yxyy => Vector4(this[1], this[0], this[1], this[1]);
-  Vector4 get yyxx => Vector4(this[1], this[1], this[0], this[0]);
-  Vector4 get yyxy => Vector4(this[1], this[1], this[0], this[1]);
-  Vector4 get yyyx => Vector4(this[1], this[1], this[1], this[0]);
-  Vector4 get yyyy => Vector4(this[1], this[1], this[1], this[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => this[0];
-  double get y => this[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -68,39 +68,36 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    storage[0] = x_;
-    storage[1] = y_;
+    this[0] = x_;
+    this[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    storage[0] = 0.0;
-    storage[1] = 0.0;
+    this[0] = 0.0;
+    this[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other.storage;
-    storage[1] = otherStorage[1];
-    storage[0] = otherStorage[0];
+    this[0] = other[0];
+    this[1] = other[1];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    storage[0] = arg;
-    storage[1] = arg;
+    this[0] = arg;
+    this[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${storage[0]},${storage[1]}]';
+  String toString() => '[${this[0]},${this[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      (other is Vector2) &&
-      (storage[0] == other.storage[0]) &&
-      (storage[1] == other.storage[1]);
+      other is Vector2 && this[0] == other[0] && this[1] == other[1];
 
   @override
   int get hashCode => Object.hashAll(storage);
@@ -139,8 +136,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      storage[0] *= l;
-      storage[1] *= l;
+      this[0] *= l;
+      this[1] *= l;
     }
   }
 
@@ -148,12 +145,7 @@ class Vector2 implements Vector {
   double get length => math.sqrt(length2);
 
   /// Length squared.
-  double get length2 {
-    double sum;
-    sum = storage[0] * storage[0];
-    sum += storage[1] * storage[1];
-    return sum;
-  }
+  double get length2 => this[0] * this[0] + this[1] * this[1];
 
   /// Normalize this.
   double normalize() {
@@ -162,8 +154,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    storage[0] *= d;
-    storage[1] *= d;
+    this[0] *= d;
+    this[1] *= d;
     return l;
   }
 
@@ -196,8 +188,7 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other.storage;
-    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
+    if (this[0] == other[0] && this[1] == other[1]) {
       return 0.0;
     }
 
@@ -208,8 +199,7 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other.storage;
-    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
+    if (this[0] == other[0] && this[1] == other[1]) {
       return 0.0;
     }
 
@@ -220,39 +210,26 @@ class Vector2 implements Vector {
   }
 
   /// Inner product.
-  double dot(Vector2 other) {
-    final otherStorage = other.storage;
-    double sum;
-    sum = storage[0] * otherStorage[0];
-    sum += storage[1] * otherStorage[1];
-    return sum;
-  }
+  double dot(Vector2 other) => this[0] * other[0] + this[1] * other[1];
 
-  ///
   /// Transforms this into the product of this as a row vector,
   /// postmultiplied by matrix, [arg].
   /// If [arg] is a rotation matrix, this is a computational shortcut for
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    final argStorage = arg.storage;
-    final v0 = storage[0];
-    final v1 = storage[1];
-    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    this[0] = this[0] * arg[0] + this[1] * arg[1];
+    this[1] = this[0] * arg[2] + this[1] * arg[3];
   }
 
   /// Cross product.
-  double cross(Vector2 other) {
-    final otherStorage = other.storage;
-    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
-  }
+  double cross(Vector2 other) => this[0] * other[1] - this[1] * other[0];
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * storage[1], scale * storage[0]);
+    out.setValues(-scale * this[1], scale * this[0]);
     return out;
   }
 
@@ -265,70 +242,52 @@ class Vector2 implements Vector {
   Vector2 reflected(Vector2 normal) => clone()..reflect(normal);
 
   /// Relative error between this and [correct]
-  double relativeError(Vector2 correct) {
-    final correct_norm = correct.length;
-    final diff_norm = (this - correct).length;
-    return diff_norm / correct_norm;
-  }
+  double relativeError(Vector2 correct) =>
+      (this - correct).length / correct.length;
 
   /// Absolute error between this and [correct]
   double absoluteError(Vector2 correct) => (this - correct).length;
 
   /// True if any component is infinite.
-  bool get isInfinite {
-    var is_infinite = false;
-    is_infinite = is_infinite || storage[0].isInfinite;
-    is_infinite = is_infinite || storage[1].isInfinite;
-    return is_infinite;
-  }
+  bool get isInfinite => this[0].isInfinite || this[1].isInfinite;
 
   /// True if any component is NaN.
-  bool get isNaN {
-    var is_nan = false;
-    is_nan = is_nan || storage[0].isNaN;
-    is_nan = is_nan || storage[1].isNaN;
-    return is_nan;
-  }
+  bool get isNaN => this[0].isNaN || this[1].isNaN;
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] + argStorage[0];
-    storage[1] = storage[1] + argStorage[1];
+    this[0] += arg[0];
+    this[1] += arg[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] + argStorage[0] * factor;
-    storage[1] = storage[1] + argStorage[1] * factor;
+    this[0] += arg[0] * factor;
+    this[1] += arg[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] - argStorage[0];
-    storage[1] = storage[1] - argStorage[1];
+    this[0] -= arg[0];
+    this[1] -= arg[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] * argStorage[0];
-    storage[1] = storage[1] * argStorage[1];
+    this[0] *= arg[0];
+    this[1] *= arg[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = storage[0] / argStorage[0];
-    storage[1] = storage[1] / argStorage[1];
+    this[0] /= arg[0];
+    this[1] /= arg[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    storage[1] = storage[1] * arg;
-    storage[0] = storage[0] * arg;
+    this[0] *= arg;
+    this[1] *= arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -336,56 +295,50 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    storage[1] = -storage[1];
-    storage[0] = -storage[0];
+    this[0] *= -1;
+    this[1] *= -1;
   }
 
   /// Absolute value.
   void absolute() {
-    storage[1] = storage[1].abs();
-    storage[0] = storage[0].abs();
+    this[0] = this[0].abs();
+    this[1] = this[1].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
-    final minStorage = min.storage;
-    final maxStorage = max.storage;
-    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    this[0] = this[0].clamp(min[0], max[0]).toDouble();
+    this[1] = this[1].clamp(min[1], max[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    storage[0] = storage[0].clamp(min, max).toDouble();
-    storage[1] = storage[1].clamp(min, max).toDouble();
+    this[0] = this[0].clamp(min, max).toDouble();
+    this[1] = this[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    storage[0] = storage[0].floorToDouble();
-    storage[1] = storage[1].floorToDouble();
+    this[0] = this[0].floorToDouble();
+    this[1] = this[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    storage[0] = storage[0].ceilToDouble();
-    storage[1] = storage[1].ceilToDouble();
+    this[0] = this[0].ceilToDouble();
+    this[1] = this[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    storage[0] = storage[0].roundToDouble();
-    storage[1] = storage[1].roundToDouble();
+    this[0] = this[0].roundToDouble();
+    this[1] = this[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    storage[0] = storage[0] < 0.0
-        ? storage[0].ceilToDouble()
-        : storage[0].floorToDouble();
-    storage[1] = storage[1] < 0.0
-        ? storage[1].ceilToDouble()
-        : storage[1].floorToDouble();
+    this[0] = this[0] < 0.0 ? this[0].ceilToDouble() : this[0].floorToDouble();
+    this[1] = this[1] < 0.0 ? this[1].ceilToDouble() : this[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -393,80 +346,77 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg.storage;
-    argStorage[1] = storage[1];
-    argStorage[0] = storage[0];
+    arg[0] = this[0];
+    arg[1] = this[1];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = storage[1];
-    array[offset + 0] = storage[0];
+    array[offset + 0] = this[0];
+    array[offset + 1] = this[1];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    storage[1] = array[offset + 1];
-    storage[0] = array[offset + 0];
+    this[0] = array[offset + 0];
+    this[1] = array[offset + 1];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[0] = argStorage[0];
-    storage[1] = argStorage[1];
+    this[0] = arg[0];
+    this[1] = arg[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg.storage;
-    storage[1] = argStorage[0];
-    storage[0] = argStorage[1];
+    this[0] = arg[1];
+    this[1] = arg[0];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => storage[0] = arg;
-  set y(double arg) => storage[1] = arg;
+  set x(double arg) => this[0] = arg;
+  set y(double arg) => this[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(storage[0], storage[0]);
-  Vector2 get xy => Vector2(storage[0], storage[1]);
-  Vector2 get yx => Vector2(storage[1], storage[0]);
-  Vector2 get yy => Vector2(storage[1], storage[1]);
-  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
-  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
-  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
-  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
-  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
-  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
-  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
-  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
-  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
-  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
-  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
-  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
-  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
-  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
-  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
-  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
-  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
-  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
-  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
-  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
-  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
-  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
-  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
-  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
+  Vector2 get xx => Vector2(this[0], this[0]);
+  Vector2 get xy => Vector2(this[0], this[1]);
+  Vector2 get yx => Vector2(this[1], this[0]);
+  Vector2 get yy => Vector2(this[1], this[1]);
+  Vector3 get xxx => Vector3(this[0], this[0], this[0]);
+  Vector3 get xxy => Vector3(this[0], this[0], this[1]);
+  Vector3 get xyx => Vector3(this[0], this[1], this[0]);
+  Vector3 get xyy => Vector3(this[0], this[1], this[1]);
+  Vector3 get yxx => Vector3(this[1], this[0], this[0]);
+  Vector3 get yxy => Vector3(this[1], this[0], this[1]);
+  Vector3 get yyx => Vector3(this[1], this[1], this[0]);
+  Vector3 get yyy => Vector3(this[1], this[1], this[1]);
+  Vector4 get xxxx => Vector4(this[0], this[0], this[0], this[0]);
+  Vector4 get xxxy => Vector4(this[0], this[0], this[0], this[1]);
+  Vector4 get xxyx => Vector4(this[0], this[0], this[1], this[0]);
+  Vector4 get xxyy => Vector4(this[0], this[0], this[1], this[1]);
+  Vector4 get xyxx => Vector4(this[0], this[1], this[0], this[0]);
+  Vector4 get xyxy => Vector4(this[0], this[1], this[0], this[1]);
+  Vector4 get xyyx => Vector4(this[0], this[1], this[1], this[0]);
+  Vector4 get xyyy => Vector4(this[0], this[1], this[1], this[1]);
+  Vector4 get yxxx => Vector4(this[1], this[0], this[0], this[0]);
+  Vector4 get yxxy => Vector4(this[1], this[0], this[0], this[1]);
+  Vector4 get yxyx => Vector4(this[1], this[0], this[1], this[0]);
+  Vector4 get yxyy => Vector4(this[1], this[0], this[1], this[1]);
+  Vector4 get yyxx => Vector4(this[1], this[1], this[0], this[0]);
+  Vector4 get yyxy => Vector4(this[1], this[1], this[0], this[1]);
+  Vector4 get yyyx => Vector4(this[1], this[1], this[1], this[0]);
+  Vector4 get yyyy => Vector4(this[1], this[1], this[1], this[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => storage[0];
-  double get y => storage[1];
+  double get x => this[0];
+  double get y => this[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -6,11 +6,9 @@ part of '../../vector_math.dart';
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float32List _v2storage;
-
   /// The components of the vector.
   @override
-  Float32List get storage => _v2storage;
+  final Float32List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -35,28 +33,31 @@ class Vector2 implements Vector {
   }
 
   /// Construct a new vector with the specified values.
-  factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
+  Vector2(double x, double y)
+      : storage = Float32List(2)
+          ..[0] = x
+          ..[1] = y;
 
   /// Initialized with values from [array] starting at [offset].
-  factory Vector2.array(List<double> array, [int offset = 0]) =>
-      Vector2.zero()..copyFromArray(array, offset);
+  Vector2.array(List<double> array, [int offset = 0])
+      : this(array[0 + offset], array[1 + offset]);
 
   /// Zero vector.
-  Vector2.zero() : _v2storage = Float32List(2);
+  Vector2.zero() : storage = Float32List(2);
 
   /// Splat [value] into all lanes of the vector.
-  factory Vector2.all(double value) => Vector2.zero()..splat(value);
+  Vector2.all(double value) : this(value, value);
 
   /// Copy of [other].
-  factory Vector2.copy(Vector2 other) => Vector2.zero()..setFrom(other);
+  Vector2.copy(Vector2 other) : this(other.x, other.y);
 
   /// Constructs Vector2 with a given [Float32List] as [storage].
-  Vector2.fromFloat32List(this._v2storage);
+  Vector2.fromFloat32List(this.storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
   /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : _v2storage = Float32List.view(buffer, offset, 2);
+      : storage = Float32List.view(buffer, offset, 2);
 
   /// Generate random vector in the range (0, 0) to (1, 1). You can
   /// optionally pass your own random number generator.
@@ -67,42 +68,42 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    _v2storage[0] = x_;
-    _v2storage[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    _v2storage[0] = 0.0;
-    _v2storage[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other._v2storage;
-    _v2storage[1] = otherStorage[1];
-    _v2storage[0] = otherStorage[0];
+    final otherStorage = other.storage;
+    storage[1] = otherStorage[1];
+    storage[0] = otherStorage[0];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    _v2storage[0] = arg;
-    _v2storage[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
       (other is Vector2) &&
-      (_v2storage[0] == other._v2storage[0]) &&
-      (_v2storage[1] == other._v2storage[1]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]);
 
   @override
-  int get hashCode => Object.hashAll(_v2storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();
@@ -120,11 +121,11 @@ class Vector2 implements Vector {
   Vector2 operator *(double scale) => clone()..scale(scale);
 
   /// Access the component of the vector at the index [i].
-  double operator [](int i) => _v2storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    _v2storage[i] = v;
+    storage[i] = v;
   }
 
   /// Set the length of the vector. A negative [value] will change the vectors
@@ -138,8 +139,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      _v2storage[0] *= l;
-      _v2storage[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -149,8 +150,8 @@ class Vector2 implements Vector {
   /// Length squared.
   double get length2 {
     double sum;
-    sum = _v2storage[0] * _v2storage[0];
-    sum += _v2storage[1] * _v2storage[1];
+    sum = storage[0] * storage[0];
+    sum += storage[1] * storage[1];
     return sum;
   }
 
@@ -161,8 +162,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    _v2storage[0] *= d;
-    _v2storage[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -195,8 +196,8 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -207,8 +208,8 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -220,10 +221,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
-    final otherStorage = other._v2storage;
+    final otherStorage = other.storage;
     double sum;
-    sum = _v2storage[0] * otherStorage[0];
-    sum += _v2storage[1] * otherStorage[1];
+    sum = storage[0] * otherStorage[0];
+    sum += storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -235,23 +236,23 @@ class Vector2 implements Vector {
   ///
   void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
-    final v0 = _v2storage[0];
-    final v1 = _v2storage[1];
-    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    final otherStorage = other._v2storage;
-    return _v2storage[0] * otherStorage[1] - _v2storage[1] * otherStorage[0];
+    final otherStorage = other.storage;
+    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
   }
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * _v2storage[1], scale * _v2storage[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -276,58 +277,58 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     var is_infinite = false;
-    is_infinite = is_infinite || _v2storage[0].isInfinite;
-    is_infinite = is_infinite || _v2storage[1].isInfinite;
+    is_infinite = is_infinite || storage[0].isInfinite;
+    is_infinite = is_infinite || storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     var is_nan = false;
-    is_nan = is_nan || _v2storage[0].isNaN;
-    is_nan = is_nan || _v2storage[1].isNaN;
+    is_nan = is_nan || storage[0].isNaN;
+    is_nan = is_nan || storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0];
-    _v2storage[1] = _v2storage[1] + argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0];
+    storage[1] = storage[1] + argStorage[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
-    _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0] * factor;
+    storage[1] = storage[1] + argStorage[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] - argStorage[0];
-    _v2storage[1] = _v2storage[1] - argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] - argStorage[0];
+    storage[1] = storage[1] - argStorage[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] * argStorage[0];
-    _v2storage[1] = _v2storage[1] * argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] * argStorage[0];
+    storage[1] = storage[1] * argStorage[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] / argStorage[0];
-    _v2storage[1] = _v2storage[1] / argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] / argStorage[0];
+    storage[1] = storage[1] / argStorage[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    _v2storage[1] = _v2storage[1] * arg;
-    _v2storage[0] = _v2storage[0] * arg;
+    storage[1] = storage[1] * arg;
+    storage[0] = storage[0] * arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -335,58 +336,56 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    _v2storage[1] = -_v2storage[1];
-    _v2storage[0] = -_v2storage[0];
+    storage[1] = -storage[1];
+    storage[0] = -storage[0];
   }
 
   /// Absolute value.
   void absolute() {
-    _v2storage[1] = _v2storage[1].abs();
-    _v2storage[0] = _v2storage[0].abs();
+    storage[1] = storage[1].abs();
+    storage[0] = storage[0].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
-    _v2storage[0] =
-        _v2storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    _v2storage[1] =
-        _v2storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
+    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    _v2storage[0] = _v2storage[0].clamp(min, max).toDouble();
-    _v2storage[1] = _v2storage[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    _v2storage[0] = _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    _v2storage[0] = _v2storage[0].ceilToDouble();
-    _v2storage[1] = _v2storage[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    _v2storage[0] = _v2storage[0].roundToDouble();
-    _v2storage[1] = _v2storage[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    _v2storage[0] = _v2storage[0] < 0.0
-        ? _v2storage[0].ceilToDouble()
-        : _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1] < 0.0
-        ? _v2storage[1].ceilToDouble()
-        : _v2storage[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -394,96 +393,80 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    argStorage[1] = _v2storage[1];
-    argStorage[0] = _v2storage[0];
+    final argStorage = arg.storage;
+    argStorage[1] = storage[1];
+    argStorage[0] = storage[0];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = _v2storage[1];
-    array[offset + 0] = _v2storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 0] = storage[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    _v2storage[1] = array[offset + 1];
-    _v2storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = argStorage[0];
-    _v2storage[1] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = argStorage[0];
+    storage[1] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[1] = argStorage[0];
-    _v2storage[0] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[1] = argStorage[0];
+    storage[0] = argStorage[1];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => _v2storage[0] = arg;
-  set y(double arg) => _v2storage[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(_v2storage[0], _v2storage[0]);
-  Vector2 get xy => Vector2(_v2storage[0], _v2storage[1]);
-  Vector2 get yx => Vector2(_v2storage[1], _v2storage[0]);
-  Vector2 get yy => Vector2(_v2storage[1], _v2storage[1]);
-  Vector3 get xxx => Vector3(_v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector3 get xxy => Vector3(_v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector3 get xyx => Vector3(_v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector3 get xyy => Vector3(_v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector3 get yxx => Vector3(_v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector3 get yxy => Vector3(_v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector3 get yyx => Vector3(_v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector3 get yyy => Vector3(_v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get xxxx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get xxxy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get xxyx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get xxyy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get xyxx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get xyxy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get xyyx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get xyyy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get yxxx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get yxxy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get yxyx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get yxyy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get yyxx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get yyxy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get yyyx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get yyyy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => _v2storage[0];
-  double get y => _v2storage[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -218,8 +218,10 @@ class Vector2 implements Vector {
   /// applying, the inverse of the transformation.
   ///
   void postmultiply(Matrix2 arg) {
-    this[0] = this[0] * arg[0] + this[1] * arg[1];
-    this[1] = this[0] * arg[2] + this[1] * arg[3];
+    final v0 = this[0];
+    final v1 = this[1];
+    this[0] = v0 * arg[0] + v1 * arg[1];
+    this[1] = v0 * arg[2] + v1 * arg[3];
   }
 
   /// Cross product.

--- a/lib/src/vector_math/vector3.dart
+++ b/lib/src/vector_math/vector3.dart
@@ -555,37 +555,37 @@ class Vector3 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }

--- a/lib/src/vector_math/vector4.dart
+++ b/lib/src/vector_math/vector4.dart
@@ -461,73 +461,73 @@ class Vector4 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set xw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set yw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set zw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set wx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set wy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set wz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -88,8 +88,8 @@ class Matrix2 {
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector2 arg0, Vector2 arg1) {
-    final arg0Storage = arg0._v2storage;
-    final arg1Storage = arg1._v2storage;
+    final arg0Storage = arg0.storage;
+    final arg1Storage = arg1.storage;
     _m2storage[0] = arg0Storage[0];
     _m2storage[1] = arg0Storage[1];
     _m2storage[2] = arg1Storage[0];
@@ -107,8 +107,8 @@ class Matrix2 {
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector2 u, Vector2 v) {
-    final uStorage = u._v2storage;
-    final vStorage = v._v2storage;
+    final uStorage = u.storage;
+    final vStorage = v.storage;
     _m2storage[0] = uStorage[0] * vStorage[0];
     _m2storage[1] = uStorage[0] * vStorage[1];
     _m2storage[2] = uStorage[1] * vStorage[0];
@@ -123,7 +123,7 @@ class Matrix2 {
 
   /// Sets the diagonal of the matrix to be [arg].
   void setDiagonal(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[0] = argStorage[0];
     _m2storage[3] = argStorage[1];
   }
@@ -169,7 +169,7 @@ class Matrix2 {
 
   /// Sets [row] of the matrix to values in [arg]
   void setRow(int row, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _m2storage[index(row, 0)] = argStorage[0];
     _m2storage[index(row, 1)] = argStorage[1];
   }
@@ -177,7 +177,7 @@ class Matrix2 {
   /// Gets the [row] of the matrix
   Vector2 getRow(int row) {
     final r = Vector2.zero();
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[0] = _m2storage[index(row, 0)];
     rStorage[1] = _m2storage[index(row, 1)];
     return r;
@@ -185,7 +185,7 @@ class Matrix2 {
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final entry = column * 2;
     _m2storage[entry + 1] = argStorage[1];
     _m2storage[entry + 0] = argStorage[0];
@@ -195,7 +195,7 @@ class Matrix2 {
   Vector2 getColumn(int column) {
     final r = Vector2.zero();
     final entry = column * 2;
-    final rStorage = r._v2storage;
+    final rStorage = r.storage;
     rStorage[1] = _m2storage[entry + 1];
     rStorage[0] = _m2storage[entry + 0];
     return r;
@@ -279,13 +279,13 @@ class Matrix2 {
 
   /// Returns the dot product of row [i] and [v].
   double dotRow(int i, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[i] * vStorage[0] + _m2storage[2 + i] * vStorage[1];
   }
 
   /// Returns the dot product of column [j] and [v].
   double dotColumn(int j, Vector2 v) {
-    final vStorage = v._v2storage;
+    final vStorage = v.storage;
     return _m2storage[j * 2] * vStorage[0] +
         _m2storage[(j * 2) + 1] * vStorage[1];
   }
@@ -468,7 +468,7 @@ class Matrix2 {
   /// Transform [arg] of type [Vector2] using the transformation defined by
   /// this.
   Vector2 transform(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = (_m2storage[0] * argStorage[0]) + (_m2storage[2] * argStorage[1]);
     final y = (_m2storage[1] * argStorage[0]) + (_m2storage[3] * argStorage[1]);
     argStorage[0] = x;

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -7,10 +7,8 @@ part of '../../vector_math_64.dart';
 /// 3D Matrix.
 /// Values are stored in column major order.
 class Matrix3 {
-  final Float64List _m3storage;
-
   /// The components of the matrix.
-  Float64List get storage => _m3storage;
+  final Float64List storage;
 
   /// Solve [A] * [x] = [b].
   static void solve2(Matrix3 A, Vector2 x, Vector2 b) {
@@ -79,51 +77,70 @@ class Matrix3 {
       ..z = z_;
   }
 
-  /// Return index in storage for [row], [col] value.
-  int index(int row, int col) => (col * 3) + row;
-
-  /// Value at [row], [col].
-  double entry(int row, int col) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    return _m3storage[index(row, col)];
-  }
-
-  /// Set value at [row], [col] to be [v].
-  void setEntry(int row, int col, double v) {
-    assert((row >= 0) && (row < dimension));
-    assert((col >= 0) && (col < dimension));
-
-    _m3storage[index(row, col)] = v;
-  }
-
   /// New matrix with specified values.
-  factory Matrix3(double arg0, double arg1, double arg2, double arg3,
-          double arg4, double arg5, double arg6, double arg7, double arg8) =>
-      Matrix3.zero()
-        ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+  Matrix3(
+    double arg0,
+    double arg1,
+    double arg2,
+    double arg3,
+    double arg4,
+    double arg5,
+    double arg6,
+    double arg7,
+    double arg8,
+  ) : storage = Float64List(9)
+          ..[0] = arg0
+          ..[1] = arg1
+          ..[2] = arg2
+          ..[3] = arg3
+          ..[4] = arg4
+          ..[5] = arg5
+          ..[6] = arg6
+          ..[7] = arg7
+          ..[8] = arg8;
 
   /// New matrix from [values].
-  factory Matrix3.fromList(List<double> values) => Matrix3.zero()
-    ..setValues(values[0], values[1], values[2], values[3], values[4],
-        values[5], values[6], values[7], values[8]);
+  Matrix3.fromList(List<double> values)
+      : storage = Float64List.fromList(values);
 
   /// Constructs a new [Matrix3] filled with zeros.
-  Matrix3.zero() : _m3storage = Float64List(9);
+  Matrix3.zero() : storage = Float64List(9);
 
   /// Identity matrix.
-  factory Matrix3.identity() => Matrix3.zero()..setIdentity();
+  Matrix3.identity()
+      : storage = Float64List(9)
+          ..[0] = 1.0
+          ..[4] = 1.0
+          ..[8] = 1.0;
 
   /// Copes values from [other].
-  factory Matrix3.copy(Matrix3 other) => Matrix3.zero()..setFrom(other);
+  Matrix3.copy(Matrix3 other) : storage = Float64List.fromList(other.storage);
 
-  /// Constructs a new mat3 from columns.
-  factory Matrix3.columns(Vector3 arg0, Vector3 arg1, Vector3 arg2) =>
-      Matrix3.zero()..setColumns(arg0, arg1, arg2);
+  /// Constructs a new [Matrix3]from columns.
+  Matrix3.columns(Vector3 arg0, Vector3 arg1, Vector3 arg2)
+      : storage = Float64List(9)
+          ..[0] = arg0[0]
+          ..[1] = arg0[1]
+          ..[2] = arg0[2]
+          ..[3] = arg1[0]
+          ..[4] = arg1[1]
+          ..[5] = arg1[2]
+          ..[6] = arg2[0]
+          ..[7] = arg2[1]
+          ..[8] = arg2[2];
 
   /// Outer product of [u] and [v].
-  factory Matrix3.outer(Vector3 u, Vector3 v) => Matrix3.zero()..setOuter(u, v);
+  Matrix3.outer(Vector3 u, Vector3 v)
+      : storage = Float64List(9)
+          ..[0] = u[0] * v[0]
+          ..[1] = u[0] * v[1]
+          ..[2] = u[0] * v[2]
+          ..[3] = u[1] * v[0]
+          ..[4] = u[1] * v[1]
+          ..[5] = u[1] * v[2]
+          ..[6] = u[2] * v[0]
+          ..[7] = u[2] * v[1]
+          ..[8] = u[2] * v[2];
 
   /// Rotation of [radians] around X axis.
   factory Matrix3.rotationX(double radians) =>
@@ -137,85 +154,98 @@ class Matrix3 {
   factory Matrix3.rotationZ(double radians) =>
       Matrix3.zero()..setRotationZ(radians);
 
+  /// Return index in storage for [row], [col] value.
+  int index(int row, int col) => (col * 3) + row;
+
+  /// Value at [row], [col].
+  double entry(int row, int col) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    return storage[index(row, col)];
+  }
+
+  /// Set value at [row], [col] to be [v].
+  void setEntry(int row, int col, double v) {
+    assert((row >= 0) && (row < dimension));
+    assert((col >= 0) && (col < dimension));
+
+    storage[index(row, col)] = v;
+  }
+
   /// Sets the matrix with specified values.
   void setValues(double arg0, double arg1, double arg2, double arg3,
       double arg4, double arg5, double arg6, double arg7, double arg8) {
-    _m3storage[8] = arg8;
-    _m3storage[7] = arg7;
-    _m3storage[6] = arg6;
-    _m3storage[5] = arg5;
-    _m3storage[4] = arg4;
-    _m3storage[3] = arg3;
-    _m3storage[2] = arg2;
-    _m3storage[1] = arg1;
-    _m3storage[0] = arg0;
+    storage[0] = arg0;
+    storage[1] = arg1;
+    storage[2] = arg2;
+    storage[3] = arg3;
+    storage[4] = arg4;
+    storage[5] = arg5;
+    storage[6] = arg6;
+    storage[7] = arg7;
+    storage[8] = arg8;
   }
 
   /// Sets the entire matrix to the column values.
   void setColumns(Vector3 arg0, Vector3 arg1, Vector3 arg2) {
-    final arg0Storage = arg0._v3storage;
-    final arg1Storage = arg1._v3storage;
-    final arg2Storage = arg2._v3storage;
-    _m3storage[0] = arg0Storage[0];
-    _m3storage[1] = arg0Storage[1];
-    _m3storage[2] = arg0Storage[2];
-    _m3storage[3] = arg1Storage[0];
-    _m3storage[4] = arg1Storage[1];
-    _m3storage[5] = arg1Storage[2];
-    _m3storage[6] = arg2Storage[0];
-    _m3storage[7] = arg2Storage[1];
-    _m3storage[8] = arg2Storage[2];
+    storage[0] = arg0[0];
+    storage[1] = arg0[1];
+    storage[2] = arg0[2];
+    storage[3] = arg1[0];
+    storage[4] = arg1[1];
+    storage[5] = arg1[2];
+    storage[6] = arg2[0];
+    storage[7] = arg2[1];
+    storage[8] = arg2[2];
   }
 
-  /// Sets the entire matrix to the matrix in [arg].
-  void setFrom(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    _m3storage[8] = argStorage[8];
-    _m3storage[7] = argStorage[7];
-    _m3storage[6] = argStorage[6];
-    _m3storage[5] = argStorage[5];
-    _m3storage[4] = argStorage[4];
-    _m3storage[3] = argStorage[3];
-    _m3storage[2] = argStorage[2];
-    _m3storage[1] = argStorage[1];
-    _m3storage[0] = argStorage[0];
+  /// Sets the entire matrix to the matrix in [other].
+  void setFrom(Matrix3 other) {
+    storage[0] = other.storage[0];
+    storage[1] = other.storage[1];
+    storage[2] = other.storage[2];
+    storage[3] = other.storage[3];
+    storage[4] = other.storage[4];
+    storage[5] = other.storage[5];
+    storage[6] = other.storage[6];
+    storage[7] = other.storage[7];
+    storage[8] = other.storage[8];
   }
 
   /// Set this to the outer product of [u] and [v].
   void setOuter(Vector3 u, Vector3 v) {
-    final uStorage = u._v3storage;
-    final vStorage = v._v3storage;
-    _m3storage[0] = uStorage[0] * vStorage[0];
-    _m3storage[1] = uStorage[0] * vStorage[1];
-    _m3storage[2] = uStorage[0] * vStorage[2];
-    _m3storage[3] = uStorage[1] * vStorage[0];
-    _m3storage[4] = uStorage[1] * vStorage[1];
-    _m3storage[5] = uStorage[1] * vStorage[2];
-    _m3storage[6] = uStorage[2] * vStorage[0];
-    _m3storage[7] = uStorage[2] * vStorage[1];
-    _m3storage[8] = uStorage[2] * vStorage[2];
+    storage[0] = u[0] * v[0];
+    storage[1] = u[0] * v[1];
+    storage[2] = u[0] * v[2];
+    storage[3] = u[1] * v[0];
+    storage[4] = u[1] * v[1];
+    storage[5] = u[1] * v[2];
+    storage[6] = u[2] * v[0];
+    storage[7] = u[2] * v[1];
+    storage[8] = u[2] * v[2];
   }
 
   /// Set the diagonal of the matrix.
   void splatDiagonal(double arg) {
-    _m3storage[0] = arg;
-    _m3storage[4] = arg;
-    _m3storage[8] = arg;
+    storage[0] = arg;
+    storage[4] = arg;
+    storage[8] = arg;
   }
 
   /// Set the diagonal of the matrix.
   void setDiagonal(Vector3 arg) {
-    _m3storage[0] = arg.storage[0];
-    _m3storage[4] = arg.storage[1];
-    _m3storage[8] = arg.storage[2];
+    storage[0] = arg[0];
+    storage[4] = arg[1];
+    storage[8] = arg[2];
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
   void setUpper2x2(Matrix2 arg) {
-    _m3storage[0] = arg.storage[0];
-    _m3storage[1] = arg.storage[1];
-    _m3storage[3] = arg.storage[2];
-    _m3storage[4] = arg.storage[3];
+    storage[0] = arg[0];
+    storage[1] = arg[1];
+    storage[3] = arg[2];
+    storage[4] = arg[3];
   }
 
   /// Returns a printable string
@@ -226,29 +256,29 @@ class Matrix3 {
   int get dimension => 3;
 
   /// Access the element of the matrix at the index [i].
-  double operator [](int i) => _m3storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the element of the matrix at the index [i].
   void operator []=(int i, double v) {
-    _m3storage[i] = v;
+    storage[i] = v;
   }
 
   /// Check if two matrices are the same.
   @override
   bool operator ==(Object other) =>
       (other is Matrix3) &&
-      (_m3storage[0] == other._m3storage[0]) &&
-      (_m3storage[1] == other._m3storage[1]) &&
-      (_m3storage[2] == other._m3storage[2]) &&
-      (_m3storage[3] == other._m3storage[3]) &&
-      (_m3storage[4] == other._m3storage[4]) &&
-      (_m3storage[5] == other._m3storage[5]) &&
-      (_m3storage[6] == other._m3storage[6]) &&
-      (_m3storage[7] == other._m3storage[7]) &&
-      (_m3storage[8] == other._m3storage[8]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]) &&
+      (storage[2] == other.storage[2]) &&
+      (storage[3] == other.storage[3]) &&
+      (storage[4] == other.storage[4]) &&
+      (storage[5] == other.storage[5]) &&
+      (storage[6] == other.storage[6]) &&
+      (storage[7] == other.storage[7]) &&
+      (storage[8] == other.storage[8]);
 
   @override
-  int get hashCode => Object.hashAll(_m3storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Returns row 0
   Vector3 get row0 => getRow(0);
@@ -270,107 +300,85 @@ class Matrix3 {
 
   /// Assigns the [row] of to [arg].
   void setRow(int row, Vector3 arg) {
-    final argStorage = arg._v3storage;
-    _m3storage[index(row, 0)] = argStorage[0];
-    _m3storage[index(row, 1)] = argStorage[1];
-    _m3storage[index(row, 2)] = argStorage[2];
+    storage[index(row, 0)] = arg[0];
+    storage[index(row, 1)] = arg[1];
+    storage[index(row, 2)] = arg[2];
   }
 
   /// Gets the [row] of the matrix
-  Vector3 getRow(int row) {
-    final r = Vector3.zero();
-    final rStorage = r._v3storage;
-    rStorage[0] = _m3storage[index(row, 0)];
-    rStorage[1] = _m3storage[index(row, 1)];
-    rStorage[2] = _m3storage[index(row, 2)];
-    return r;
-  }
+  Vector3 getRow(int row) => Vector3(
+        storage[index(row, 0)],
+        storage[index(row, 1)],
+        storage[index(row, 2)],
+      );
 
   /// Assigns the [column] of the matrix [arg]
   void setColumn(int column, Vector3 arg) {
-    final argStorage = arg._v3storage;
     final entry = column * 3;
-    _m3storage[entry + 2] = argStorage[2];
-    _m3storage[entry + 1] = argStorage[1];
-    _m3storage[entry + 0] = argStorage[0];
+    storage[entry + 2] = arg[2];
+    storage[entry + 1] = arg[1];
+    storage[entry + 0] = arg[0];
   }
 
   /// Gets the [column] of the matrix
   Vector3 getColumn(int column) {
-    final r = Vector3.zero();
-    final rStorage = r._v3storage;
     final entry = column * 3;
-    rStorage[2] = _m3storage[entry + 2];
-    rStorage[1] = _m3storage[entry + 1];
-    rStorage[0] = _m3storage[entry + 0];
-    return r;
+    return Vector3(storage[entry + 0], storage[entry + 1], storage[entry + 2]);
   }
 
   /// Clone of this.
   Matrix3 clone() => Matrix3.copy(this);
 
-  /// Copy this into [arg].
-  Matrix3 copyInto(Matrix3 arg) {
-    final argStorage = arg._m3storage;
-    argStorage[0] = _m3storage[0];
-    argStorage[1] = _m3storage[1];
-    argStorage[2] = _m3storage[2];
-    argStorage[3] = _m3storage[3];
-    argStorage[4] = _m3storage[4];
-    argStorage[5] = _m3storage[5];
-    argStorage[6] = _m3storage[6];
-    argStorage[7] = _m3storage[7];
-    argStorage[8] = _m3storage[8];
-    return arg;
+  /// Copy this into [other].
+  Matrix3 copyInto(Matrix3 other) => other..setFrom(this);
+
+  /// Returns a new vector or matrix by multiplying this with [other].
+  dynamic operator *(dynamic other) {
+    if (other is double) {
+      return scaled(other);
+    }
+    if (other is Vector3) {
+      return transformed(other);
+    }
+    if (other is Matrix3) {
+      return multiplied(other);
+    }
+    throw ArgumentError(other);
   }
 
-  /// Returns a new vector or matrix by multiplying this with [arg].
-  dynamic operator *(dynamic arg) {
-    if (arg is double) {
-      return scaled(arg);
-    }
-    if (arg is Vector3) {
-      return transformed(arg);
-    }
-    if (arg is Matrix3) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
-  }
+  /// Returns new matrix after component wise this + [other]
+  Matrix3 operator +(Matrix3 other) => clone()..add(other);
 
-  /// Returns new matrix after component wise this + [arg]
-  Matrix3 operator +(Matrix3 arg) => clone()..add(arg);
-
-  /// Returns new matrix after component wise this - [arg]
-  Matrix3 operator -(Matrix3 arg) => clone()..sub(arg);
+  /// Returns new matrix after component wise this - [other]
+  Matrix3 operator -(Matrix3 other) => clone()..sub(other);
 
   /// Returns new matrix -this
   Matrix3 operator -() => clone()..negate();
 
   /// Zeros this.
   void setZero() {
-    _m3storage[0] = 0.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 0.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 0.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 0.0;
   }
 
   /// Makes this into the identity matrix.
   void setIdentity() {
-    _m3storage[0] = 1.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 1.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 1.0;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Returns the tranpose of this.
@@ -379,95 +387,67 @@ class Matrix3 {
   /// Transpose this.
   void transpose() {
     double temp;
-    temp = _m3storage[3];
-    _m3storage[3] = _m3storage[1];
-    _m3storage[1] = temp;
-    temp = _m3storage[6];
-    _m3storage[6] = _m3storage[2];
-    _m3storage[2] = temp;
-    temp = _m3storage[7];
-    _m3storage[7] = _m3storage[5];
-    _m3storage[5] = temp;
+    temp = storage[3];
+    storage[3] = storage[1];
+    storage[1] = temp;
+    temp = storage[6];
+    storage[6] = storage[2];
+    storage[2] = temp;
+    temp = storage[7];
+    storage[7] = storage[5];
+    storage[5] = temp;
   }
 
   /// Returns the component wise absolute value of this.
-  Matrix3 absolute() {
-    final r = Matrix3.zero();
-    final rStorage = r._m3storage;
-    rStorage[0] = _m3storage[0].abs();
-    rStorage[1] = _m3storage[1].abs();
-    rStorage[2] = _m3storage[2].abs();
-    rStorage[3] = _m3storage[3].abs();
-    rStorage[4] = _m3storage[4].abs();
-    rStorage[5] = _m3storage[5].abs();
-    rStorage[6] = _m3storage[6].abs();
-    rStorage[7] = _m3storage[7].abs();
-    rStorage[8] = _m3storage[8].abs();
-    return r;
-  }
+  Matrix3 absolute() => Matrix3(
+        storage[0].abs(),
+        storage[1].abs(),
+        storage[2].abs(),
+        storage[3].abs(),
+        storage[4].abs(),
+        storage[5].abs(),
+        storage[6].abs(),
+        storage[7].abs(),
+        storage[8].abs(),
+      );
 
   /// Returns the determinant of this matrix.
   double determinant() {
-    final x = _m3storage[0] *
-        ((_m3storage[4] * _m3storage[8]) - (_m3storage[5] * _m3storage[7]));
-    final y = _m3storage[1] *
-        ((_m3storage[3] * _m3storage[8]) - (_m3storage[5] * _m3storage[6]));
-    final z = _m3storage[2] *
-        ((_m3storage[3] * _m3storage[7]) - (_m3storage[4] * _m3storage[6]));
+    final x =
+        storage[0] * ((storage[4] * storage[8]) - (storage[5] * storage[7]));
+    final y =
+        storage[1] * ((storage[3] * storage[8]) - (storage[5] * storage[6]));
+    final z =
+        storage[2] * ((storage[3] * storage[7]) - (storage[4] * storage[6]));
     return x - y + z;
   }
 
   /// Returns the dot product of row [i] and [v].
-  double dotRow(int i, Vector3 v) {
-    final vStorage = v._v3storage;
-    return _m3storage[i] * vStorage[0] +
-        _m3storage[3 + i] * vStorage[1] +
-        _m3storage[6 + i] * vStorage[2];
-  }
+  double dotRow(int i, Vector3 v) =>
+      storage[i] * v[0] + storage[3 + i] * v[1] + storage[6 + i] * v[2];
 
   /// Returns the dot product of column [j] and [v].
-  double dotColumn(int j, Vector3 v) {
-    final vStorage = v._v3storage;
-    return _m3storage[j * 3] * vStorage[0] +
-        _m3storage[j * 3 + 1] * vStorage[1] +
-        _m3storage[j * 3 + 2] * vStorage[2];
-  }
+  double dotColumn(int j, Vector3 v) =>
+      storage[j * 3] * v[0] +
+      storage[j * 3 + 1] * v[1] +
+      storage[j * 3 + 2] * v[2];
 
   /// Returns the trace of the matrix. The trace of a matrix is the sum of
   /// the diagonal entries.
   double trace() {
     var t = 0.0;
-    t += _m3storage[0];
-    t += _m3storage[4];
-    t += _m3storage[8];
+    t += storage[0];
+    t += storage[4];
+    t += storage[8];
     return t;
   }
 
   /// Returns infinity norm of the matrix. Used for numerical analysis.
   double infinityNorm() {
-    var norm = 0.0;
-    {
-      var row_norm = 0.0;
-      row_norm += _m3storage[0].abs();
-      row_norm += _m3storage[1].abs();
-      row_norm += _m3storage[2].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    {
-      var row_norm = 0.0;
-      row_norm += _m3storage[3].abs();
-      row_norm += _m3storage[4].abs();
-      row_norm += _m3storage[5].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    {
-      var row_norm = 0.0;
-      row_norm += _m3storage[6].abs();
-      row_norm += _m3storage[7].abs();
-      row_norm += _m3storage[8].abs();
-      norm = row_norm > norm ? row_norm : norm;
-    }
-    return norm;
+    final row1 = storage[0].abs() + storage[1].abs() + storage[2].abs();
+    final row2 = storage[3].abs() + storage[4].abs() + storage[5].abs();
+    final row3 = storage[6].abs() + storage[7].abs() + storage[8].abs();
+    return math.max(row1, math.max(row2, math.max(row3, 0)));
   }
 
   /// Returns relative error between this and [correct]
@@ -489,42 +469,50 @@ class Matrix3 {
   /// Invert the matrix. Returns the determinant.
   double invert() => copyInverse(this);
 
-  /// Set this matrix to be the inverse of [arg]
-  double copyInverse(Matrix3 arg) {
-    final det = arg.determinant();
+  /// Set this matrix to be the inverse of [other]
+  double copyInverse(Matrix3 other) {
+    final det = other.determinant();
     if (det == 0.0) {
-      setFrom(arg);
+      setFrom(other);
       return 0.0;
     }
     final invDet = 1.0 / det;
-    final argStorage = arg._m3storage;
     final ix = invDet *
-        (argStorage[4] * argStorage[8] - argStorage[5] * argStorage[7]);
+        (other.storage[4] * other.storage[8] -
+            other.storage[5] * other.storage[7]);
     final iy = invDet *
-        (argStorage[2] * argStorage[7] - argStorage[1] * argStorage[8]);
+        (other.storage[2] * other.storage[7] -
+            other.storage[1] * other.storage[8]);
     final iz = invDet *
-        (argStorage[1] * argStorage[5] - argStorage[2] * argStorage[4]);
+        (other.storage[1] * other.storage[5] -
+            other.storage[2] * other.storage[4]);
     final jx = invDet *
-        (argStorage[5] * argStorage[6] - argStorage[3] * argStorage[8]);
+        (other.storage[5] * other.storage[6] -
+            other.storage[3] * other.storage[8]);
     final jy = invDet *
-        (argStorage[0] * argStorage[8] - argStorage[2] * argStorage[6]);
+        (other.storage[0] * other.storage[8] -
+            other.storage[2] * other.storage[6]);
     final jz = invDet *
-        (argStorage[2] * argStorage[3] - argStorage[0] * argStorage[5]);
+        (other.storage[2] * other.storage[3] -
+            other.storage[0] * other.storage[5]);
     final kx = invDet *
-        (argStorage[3] * argStorage[7] - argStorage[4] * argStorage[6]);
+        (other.storage[3] * other.storage[7] -
+            other.storage[4] * other.storage[6]);
     final ky = invDet *
-        (argStorage[1] * argStorage[6] - argStorage[0] * argStorage[7]);
+        (other.storage[1] * other.storage[6] -
+            other.storage[0] * other.storage[7]);
     final kz = invDet *
-        (argStorage[0] * argStorage[4] - argStorage[1] * argStorage[3]);
-    _m3storage[0] = ix;
-    _m3storage[1] = iy;
-    _m3storage[2] = iz;
-    _m3storage[3] = jx;
-    _m3storage[4] = jy;
-    _m3storage[5] = jz;
-    _m3storage[6] = kx;
-    _m3storage[7] = ky;
-    _m3storage[8] = kz;
+        (other.storage[0] * other.storage[4] -
+            other.storage[1] * other.storage[3]);
+    storage[0] = ix;
+    storage[1] = iy;
+    storage[2] = iz;
+    storage[3] = jx;
+    storage[4] = jy;
+    storage[5] = jz;
+    storage[6] = kx;
+    storage[7] = ky;
+    storage[8] = kz;
     return det;
   }
 
@@ -538,89 +526,88 @@ class Matrix3 {
   void setRotationX(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = 1.0;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = c;
-    _m3storage[5] = s;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = -s;
-    _m3storage[8] = c;
+    storage[0] = 1.0;
+    storage[1] = 0.0;
+    storage[2] = 0.0;
+    storage[3] = 0.0;
+    storage[4] = c;
+    storage[5] = s;
+    storage[6] = 0.0;
+    storage[7] = -s;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Y
   void setRotationY(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = c;
-    _m3storage[1] = 0.0;
-    _m3storage[2] = s;
-    _m3storage[3] = 0.0;
-    _m3storage[4] = 1.0;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = -s;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = c;
+    storage[0] = c;
+    storage[1] = 0.0;
+    storage[2] = s;
+    storage[3] = 0.0;
+    storage[4] = 1.0;
+    storage[5] = 0.0;
+    storage[6] = -s;
+    storage[7] = 0.0;
+    storage[8] = c;
   }
 
   /// Turns the matrix into a rotation of [radians] around Z
   void setRotationZ(double radians) {
     final c = math.cos(radians);
     final s = math.sin(radians);
-    _m3storage[0] = c;
-    _m3storage[1] = s;
-    _m3storage[2] = 0.0;
-    _m3storage[3] = -s;
-    _m3storage[4] = c;
-    _m3storage[5] = 0.0;
-    _m3storage[6] = 0.0;
-    _m3storage[7] = 0.0;
-    _m3storage[8] = 1.0;
+    storage[0] = c;
+    storage[1] = s;
+    storage[2] = 0.0;
+    storage[3] = -s;
+    storage[4] = c;
+    storage[5] = 0.0;
+    storage[6] = 0.0;
+    storage[7] = 0.0;
+    storage[8] = 1.0;
   }
 
   /// Converts into Adjugate matrix and scales by [scale]
   void scaleAdjoint(double scale) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    _m3storage[0] = (m11 * m22 - m12 * m21) * scale;
-    _m3storage[1] = (m12 * m20 - m10 * m22) * scale;
-    _m3storage[2] = (m10 * m21 - m11 * m20) * scale;
-    _m3storage[3] = (m02 * m21 - m01 * m22) * scale;
-    _m3storage[4] = (m00 * m22 - m02 * m20) * scale;
-    _m3storage[5] = (m01 * m20 - m00 * m21) * scale;
-    _m3storage[6] = (m01 * m12 - m02 * m11) * scale;
-    _m3storage[7] = (m02 * m10 - m00 * m12) * scale;
-    _m3storage[8] = (m00 * m11 - m01 * m10) * scale;
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    storage[0] = (m11 * m22 - m12 * m21) * scale;
+    storage[1] = (m12 * m20 - m10 * m22) * scale;
+    storage[2] = (m10 * m21 - m11 * m20) * scale;
+    storage[3] = (m02 * m21 - m01 * m22) * scale;
+    storage[4] = (m00 * m22 - m02 * m20) * scale;
+    storage[5] = (m01 * m20 - m00 * m21) * scale;
+    storage[6] = (m01 * m12 - m02 * m11) * scale;
+    storage[7] = (m02 * m10 - m00 * m12) * scale;
+    storage[8] = (m00 * m11 - m01 * m10) * scale;
   }
 
   /// Rotates [arg] by the absolute rotation of this
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector3 absoluteRotate(Vector3 arg) {
-    final m00 = _m3storage[0].abs();
-    final m01 = _m3storage[3].abs();
-    final m02 = _m3storage[6].abs();
-    final m10 = _m3storage[1].abs();
-    final m11 = _m3storage[4].abs();
-    final m12 = _m3storage[7].abs();
-    final m20 = _m3storage[2].abs();
-    final m21 = _m3storage[5].abs();
-    final m22 = _m3storage[8].abs();
-    final argStorage = arg._v3storage;
-    final x = argStorage[0];
-    final y = argStorage[1];
-    final z = argStorage[2];
-    argStorage[0] = x * m00 + y * m01 + z * m02;
-    argStorage[1] = x * m10 + y * m11 + z * m12;
-    argStorage[2] = x * m20 + y * m21 + z * m22;
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m02 = storage[6].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
+    final m12 = storage[7].abs();
+    final m20 = storage[2].abs();
+    final m21 = storage[5].abs();
+    final m22 = storage[8].abs();
+    final x = arg[0];
+    final y = arg[1];
+    final z = arg[2];
+    arg[0] = x * m00 + y * m01 + z * m02;
+    arg[1] = x * m10 + y * m11 + z * m12;
+    arg[2] = x * m20 + y * m21 + z * m22;
     return arg;
   }
 
@@ -628,306 +615,261 @@ class Matrix3 {
   /// Returns [arg].
   /// Primarily used by AABB transformation code.
   Vector2 absoluteRotate2(Vector2 arg) {
-    final m00 = _m3storage[0].abs();
-    final m01 = _m3storage[3].abs();
-    final m10 = _m3storage[1].abs();
-    final m11 = _m3storage[4].abs();
-    final argStorage = arg.storage;
-    final x = argStorage[0];
-    final y = argStorage[1];
-    argStorage[0] = x * m00 + y * m01;
-    argStorage[1] = x * m10 + y * m11;
+    final m00 = storage[0].abs();
+    final m01 = storage[3].abs();
+    final m10 = storage[1].abs();
+    final m11 = storage[4].abs();
+    final x = arg[0];
+    final y = arg[1];
+    arg[0] = x * m00 + y * m01;
+    arg[1] = x * m10 + y * m11;
     return arg;
   }
 
   /// Transforms [arg] with this.
-  Vector2 transform2(Vector2 arg) {
-    final argStorage = arg.storage;
-    final x_ = (_m3storage[0] * argStorage[0]) +
-        (_m3storage[3] * argStorage[1]) +
-        _m3storage[6];
-    final y_ = (_m3storage[1] * argStorage[0]) +
-        (_m3storage[4] * argStorage[1]) +
-        _m3storage[7];
-    argStorage[0] = x_;
-    argStorage[1] = y_;
-    return arg;
-  }
+  Vector2 transform2(Vector2 arg) => arg
+    ..setValues(
+      (storage[0] * arg[0]) + (storage[3] * arg[1]) + storage[6],
+      (storage[1] * arg[0]) + (storage[4] * arg[1]) + storage[7],
+    );
 
   /// Scales this by [scale].
   void scale(double scale) {
-    _m3storage[0] = _m3storage[0] * scale;
-    _m3storage[1] = _m3storage[1] * scale;
-    _m3storage[2] = _m3storage[2] * scale;
-    _m3storage[3] = _m3storage[3] * scale;
-    _m3storage[4] = _m3storage[4] * scale;
-    _m3storage[5] = _m3storage[5] * scale;
-    _m3storage[6] = _m3storage[6] * scale;
-    _m3storage[7] = _m3storage[7] * scale;
-    _m3storage[8] = _m3storage[8] * scale;
+    storage[0] *= scale;
+    storage[1] *= scale;
+    storage[2] *= scale;
+    storage[3] *= scale;
+    storage[4] *= scale;
+    storage[5] *= scale;
+    storage[6] *= scale;
+    storage[7] *= scale;
+    storage[8] *= scale;
   }
 
   /// Create a copy of this and scale it by [scale].
   Matrix3 scaled(double scale) => clone()..scale(scale);
 
-  /// Add [o] to this.
-  void add(Matrix3 o) {
-    final oStorage = o._m3storage;
-    _m3storage[0] = _m3storage[0] + oStorage[0];
-    _m3storage[1] = _m3storage[1] + oStorage[1];
-    _m3storage[2] = _m3storage[2] + oStorage[2];
-    _m3storage[3] = _m3storage[3] + oStorage[3];
-    _m3storage[4] = _m3storage[4] + oStorage[4];
-    _m3storage[5] = _m3storage[5] + oStorage[5];
-    _m3storage[6] = _m3storage[6] + oStorage[6];
-    _m3storage[7] = _m3storage[7] + oStorage[7];
-    _m3storage[8] = _m3storage[8] + oStorage[8];
+  /// Add [other] to this.
+  void add(Matrix3 other) {
+    storage[0] += other.storage[0];
+    storage[1] += other.storage[1];
+    storage[2] += other.storage[2];
+    storage[3] += other.storage[3];
+    storage[4] += other.storage[4];
+    storage[5] += other.storage[5];
+    storage[6] += other.storage[6];
+    storage[7] += other.storage[7];
+    storage[8] += other.storage[8];
   }
 
-  /// Subtract [o] from this.
-  void sub(Matrix3 o) {
-    final oStorage = o._m3storage;
-    _m3storage[0] = _m3storage[0] - oStorage[0];
-    _m3storage[1] = _m3storage[1] - oStorage[1];
-    _m3storage[2] = _m3storage[2] - oStorage[2];
-    _m3storage[3] = _m3storage[3] - oStorage[3];
-    _m3storage[4] = _m3storage[4] - oStorage[4];
-    _m3storage[5] = _m3storage[5] - oStorage[5];
-    _m3storage[6] = _m3storage[6] - oStorage[6];
-    _m3storage[7] = _m3storage[7] - oStorage[7];
-    _m3storage[8] = _m3storage[8] - oStorage[8];
+  /// Subtract [other] from this.
+  void sub(Matrix3 other) {
+    storage[0] -= other.storage[0];
+    storage[1] -= other.storage[1];
+    storage[2] -= other.storage[2];
+    storage[3] -= other.storage[3];
+    storage[4] -= other.storage[4];
+    storage[5] -= other.storage[5];
+    storage[6] -= other.storage[6];
+    storage[7] -= other.storage[7];
+    storage[8] -= other.storage[8];
   }
 
   /// Negate this.
   void negate() {
-    _m3storage[0] = -_m3storage[0];
-    _m3storage[1] = -_m3storage[1];
-    _m3storage[2] = -_m3storage[2];
-    _m3storage[3] = -_m3storage[3];
-    _m3storage[4] = -_m3storage[4];
-    _m3storage[5] = -_m3storage[5];
-    _m3storage[6] = -_m3storage[6];
-    _m3storage[7] = -_m3storage[7];
-    _m3storage[8] = -_m3storage[8];
+    storage[0] *= -1;
+    storage[1] *= -1;
+    storage[2] *= -1;
+    storage[3] *= -1;
+    storage[4] *= -1;
+    storage[5] *= -1;
+    storage[6] *= -1;
+    storage[7] *= -1;
+    storage[8] *= -1;
   }
 
-  /// Multiply this by [arg].
-  void multiply(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
-    final n00 = argStorage[0];
-    final n01 = argStorage[3];
-    final n02 = argStorage[6];
-    final n10 = argStorage[1];
-    final n11 = argStorage[4];
-    final n12 = argStorage[7];
-    final n20 = argStorage[2];
-    final n21 = argStorage[5];
-    final n22 = argStorage[8];
-    _m3storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
-    _m3storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
-    _m3storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
-    _m3storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
-    _m3storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
-    _m3storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
-    _m3storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
-    _m3storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
-    _m3storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
+  /// Multiply this by [other].
+  void multiply(Matrix3 other) {
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
-  /// Create a copy of this and multiply it by [arg].
-  Matrix3 multiplied(Matrix3 arg) => clone()..multiply(arg);
+  /// Create a copy of this and multiply it by [other].
+  Matrix3 multiplied(Matrix3 other) => clone()..multiply(other);
 
-  void transposeMultiply(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[1];
-    final m02 = _m3storage[2];
-    final m10 = _m3storage[3];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[5];
-    final m20 = _m3storage[6];
-    final m21 = _m3storage[7];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
-    _m3storage[0] =
-        (m00 * argStorage[0]) + (m01 * argStorage[1]) + (m02 * argStorage[2]);
-    _m3storage[3] =
-        (m00 * argStorage[3]) + (m01 * argStorage[4]) + (m02 * argStorage[5]);
-    _m3storage[6] =
-        (m00 * argStorage[6]) + (m01 * argStorage[7]) + (m02 * argStorage[8]);
-    _m3storage[1] =
-        (m10 * argStorage[0]) + (m11 * argStorage[1]) + (m12 * argStorage[2]);
-    _m3storage[4] =
-        (m10 * argStorage[3]) + (m11 * argStorage[4]) + (m12 * argStorage[5]);
-    _m3storage[7] =
-        (m10 * argStorage[6]) + (m11 * argStorage[7]) + (m12 * argStorage[8]);
-    _m3storage[2] =
-        (m20 * argStorage[0]) + (m21 * argStorage[1]) + (m22 * argStorage[2]);
-    _m3storage[5] =
-        (m20 * argStorage[3]) + (m21 * argStorage[4]) + (m22 * argStorage[5]);
-    _m3storage[8] =
-        (m20 * argStorage[6]) + (m21 * argStorage[7]) + (m22 * argStorage[8]);
+  void transposeMultiply(Matrix3 other) {
+    final m00 = storage[0];
+    final m01 = storage[1];
+    final m02 = storage[2];
+    final m10 = storage[3];
+    final m11 = storage[4];
+    final m12 = storage[5];
+    final m20 = storage[6];
+    final m21 = storage[7];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n10) + (m02 * n20);
+    storage[3] = (m00 * n01) + (m01 * n11) + (m02 * n21);
+    storage[6] = (m00 * n02) + (m01 * n12) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n10) + (m12 * n20);
+    storage[4] = (m10 * n01) + (m11 * n11) + (m12 * n21);
+    storage[7] = (m10 * n02) + (m11 * n12) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n10) + (m22 * n20);
+    storage[5] = (m20 * n01) + (m21 * n11) + (m22 * n21);
+    storage[8] = (m20 * n02) + (m21 * n12) + (m22 * n22);
   }
 
-  void multiplyTranspose(Matrix3 arg) {
-    final m00 = _m3storage[0];
-    final m01 = _m3storage[3];
-    final m02 = _m3storage[6];
-    final m10 = _m3storage[1];
-    final m11 = _m3storage[4];
-    final m12 = _m3storage[7];
-    final m20 = _m3storage[2];
-    final m21 = _m3storage[5];
-    final m22 = _m3storage[8];
-    final argStorage = arg._m3storage;
-    _m3storage[0] =
-        (m00 * argStorage[0]) + (m01 * argStorage[3]) + (m02 * argStorage[6]);
-    _m3storage[3] =
-        (m00 * argStorage[1]) + (m01 * argStorage[4]) + (m02 * argStorage[7]);
-    _m3storage[6] =
-        (m00 * argStorage[2]) + (m01 * argStorage[5]) + (m02 * argStorage[8]);
-    _m3storage[1] =
-        (m10 * argStorage[0]) + (m11 * argStorage[3]) + (m12 * argStorage[6]);
-    _m3storage[4] =
-        (m10 * argStorage[1]) + (m11 * argStorage[4]) + (m12 * argStorage[7]);
-    _m3storage[7] =
-        (m10 * argStorage[2]) + (m11 * argStorage[5]) + (m12 * argStorage[8]);
-    _m3storage[2] =
-        (m20 * argStorage[0]) + (m21 * argStorage[3]) + (m22 * argStorage[6]);
-    _m3storage[5] =
-        (m20 * argStorage[1]) + (m21 * argStorage[4]) + (m22 * argStorage[7]);
-    _m3storage[8] =
-        (m20 * argStorage[2]) + (m21 * argStorage[5]) + (m22 * argStorage[8]);
+  void multiplyTranspose(Matrix3 other) {
+    final m00 = storage[0];
+    final m01 = storage[3];
+    final m02 = storage[6];
+    final m10 = storage[1];
+    final m11 = storage[4];
+    final m12 = storage[7];
+    final m20 = storage[2];
+    final m21 = storage[5];
+    final m22 = storage[8];
+    final n00 = other.storage[0];
+    final n01 = other.storage[3];
+    final n02 = other.storage[6];
+    final n10 = other.storage[1];
+    final n11 = other.storage[4];
+    final n12 = other.storage[7];
+    final n20 = other.storage[2];
+    final n21 = other.storage[5];
+    final n22 = other.storage[8];
+    storage[0] = (m00 * n00) + (m01 * n01) + (m02 * n02);
+    storage[3] = (m00 * n10) + (m01 * n11) + (m02 * n12);
+    storage[6] = (m00 * n20) + (m01 * n21) + (m02 * n22);
+    storage[1] = (m10 * n00) + (m11 * n01) + (m12 * n02);
+    storage[4] = (m10 * n10) + (m11 * n11) + (m12 * n12);
+    storage[7] = (m10 * n20) + (m11 * n21) + (m12 * n22);
+    storage[2] = (m20 * n00) + (m21 * n01) + (m22 * n02);
+    storage[5] = (m20 * n10) + (m21 * n11) + (m22 * n12);
+    storage[8] = (m20 * n20) + (m21 * n21) + (m22 * n22);
   }
 
   /// Transform [arg] of type [Vector3] using the transformation defined by
   /// this.
-  Vector3 transform(Vector3 arg) {
-    final argStorage = arg._v3storage;
-    final x_ = (_m3storage[0] * argStorage[0]) +
-        (_m3storage[3] * argStorage[1]) +
-        (_m3storage[6] * argStorage[2]);
-    final y_ = (_m3storage[1] * argStorage[0]) +
-        (_m3storage[4] * argStorage[1]) +
-        (_m3storage[7] * argStorage[2]);
-    final z_ = (_m3storage[2] * argStorage[0]) +
-        (_m3storage[5] * argStorage[1]) +
-        (_m3storage[8] * argStorage[2]);
-    arg
-      ..x = x_
-      ..y = y_
-      ..z = z_;
-    return arg;
-  }
+  Vector3 transform(Vector3 arg) => arg
+    ..setValues(
+      (storage[0] * arg[0]) + (storage[3] * arg[1]) + (storage[6] * arg[2]),
+      (storage[1] * arg[0]) + (storage[4] * arg[1]) + (storage[7] * arg[2]),
+      (storage[2] * arg[0]) + (storage[5] * arg[1]) + (storage[8] * arg[2]),
+    );
 
   /// Transform a copy of [arg] of type [Vector3] using the transformation
   /// defined by this. If a [out] parameter is supplied, the copy is stored in
   /// [out].
   Vector3 transformed(Vector3 arg, [Vector3? out]) {
-    if (out == null) {
-      out = Vector3.copy(arg);
-    } else {
-      out.setFrom(arg);
-    }
-    return transform(out);
+    final outLocal = (out?..setFrom(arg)) ?? arg.clone();
+    return transform(outLocal);
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<num> array, [int offset = 0]) {
-    final i = offset;
-    array[i + 8] = _m3storage[8];
-    array[i + 7] = _m3storage[7];
-    array[i + 6] = _m3storage[6];
-    array[i + 5] = _m3storage[5];
-    array[i + 4] = _m3storage[4];
-    array[i + 3] = _m3storage[3];
-    array[i + 2] = _m3storage[2];
-    array[i + 1] = _m3storage[1];
-    array[i + 0] = _m3storage[0];
+    array[offset + 0] = storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 2] = storage[2];
+    array[offset + 3] = storage[3];
+    array[offset + 4] = storage[4];
+    array[offset + 5] = storage[5];
+    array[offset + 6] = storage[6];
+    array[offset + 7] = storage[7];
+    array[offset + 8] = storage[8];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    final i = offset;
-    _m3storage[8] = array[i + 8];
-    _m3storage[7] = array[i + 7];
-    _m3storage[6] = array[i + 6];
-    _m3storage[5] = array[i + 5];
-    _m3storage[4] = array[i + 4];
-    _m3storage[3] = array[i + 3];
-    _m3storage[2] = array[i + 2];
-    _m3storage[1] = array[i + 1];
-    _m3storage[0] = array[i + 0];
+    storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[2] = array[offset + 2];
+    storage[3] = array[offset + 3];
+    storage[4] = array[offset + 4];
+    storage[5] = array[offset + 5];
+    storage[6] = array[offset + 6];
+    storage[7] = array[offset + 7];
+    storage[8] = array[offset + 8];
   }
 
   /// Multiply this to each set of xyz values in [array] starting at [offset].
   List<double> applyToVector3Array(List<double> array, [int offset = 0]) {
     for (var i = 0, j = offset; i < array.length; i += 3, j += 3) {
       final v = Vector3.array(array, j)..applyMatrix3(this);
-      array[j] = v.storage[0];
-      array[j + 1] = v.storage[1];
-      array[j + 2] = v.storage[2];
+      array[j] = v[0];
+      array[j + 1] = v[1];
+      array[j + 2] = v[2];
     }
 
     return array;
   }
 
-  Vector3 get right {
-    final x = _m3storage[0];
-    final y = _m3storage[1];
-    final z = _m3storage[2];
-    return Vector3(x, y, z);
-  }
+  Vector3 get right => Vector3(storage[0], storage[1], storage[2]);
 
-  Vector3 get up {
-    final x = _m3storage[3];
-    final y = _m3storage[4];
-    final z = _m3storage[5];
-    return Vector3(x, y, z);
-  }
+  Vector3 get up => Vector3(storage[3], storage[4], storage[5]);
 
-  Vector3 get forward {
-    final x = _m3storage[6];
-    final y = _m3storage[7];
-    final z = _m3storage[8];
-    return Vector3(x, y, z);
-  }
+  Vector3 get forward => Vector3(storage[6], storage[7], storage[8]);
 
   /// Is this the identity matrix?
   bool isIdentity() =>
-      _m3storage[0] == 1.0 // col 1
+      storage[0] == 1.0 // col 1
       &&
-      _m3storage[1] == 0.0 &&
-      _m3storage[2] == 0.0 &&
-      _m3storage[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      _m3storage[4] == 1.0 &&
-      _m3storage[5] == 0.0 &&
-      _m3storage[6] == 0.0 // col 3
+      storage[4] == 1.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      _m3storage[7] == 0.0 &&
-      _m3storage[8] == 1.0;
+      storage[7] == 0.0 &&
+      storage[8] == 1.0;
 
   /// Is this the zero matrix?
   bool isZero() =>
-      _m3storage[0] == 0.0 // col 1
+      storage[0] == 0.0 // col 1
       &&
-      _m3storage[1] == 0.0 &&
-      _m3storage[2] == 0.0 &&
-      _m3storage[3] == 0.0 // col 2
+      storage[1] == 0.0 &&
+      storage[2] == 0.0 &&
+      storage[3] == 0.0 // col 2
       &&
-      _m3storage[4] == 0.0 &&
-      _m3storage[5] == 0.0 &&
-      _m3storage[6] == 0.0 // col 3
+      storage[4] == 0.0 &&
+      storage[5] == 0.0 &&
+      storage[6] == 0.0 // col 3
       &&
-      _m3storage[7] == 0.0 &&
-      _m3storage[8] == 0.0;
+      storage[7] == 0.0 &&
+      storage[8] == 0.0;
 }

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -633,7 +633,7 @@ class Matrix3 {
     final m01 = _m3storage[3].abs();
     final m10 = _m3storage[1].abs();
     final m11 = _m3storage[4].abs();
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x = argStorage[0];
     final y = argStorage[1];
     argStorage[0] = x * m00 + y * m01;
@@ -643,7 +643,7 @@ class Matrix3 {
 
   /// Transforms [arg] with this.
   Vector2 transform2(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     final x_ = (_m3storage[0] * argStorage[0]) +
         (_m3storage[3] * argStorage[1]) +
         _m3storage[6];

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -1146,30 +1146,28 @@ class Matrix4 {
   /// Copies the rotation matrix from this homogeneous transformation matrix
   /// into [rotation].
   void copyRotation(Matrix3 rotation) {
-    final rStorage = rotation._m3storage;
-    rStorage[0] = _m4storage[0];
-    rStorage[1] = _m4storage[1];
-    rStorage[2] = _m4storage[2];
-    rStorage[3] = _m4storage[4];
-    rStorage[4] = _m4storage[5];
-    rStorage[5] = _m4storage[6];
-    rStorage[6] = _m4storage[8];
-    rStorage[7] = _m4storage[9];
-    rStorage[8] = _m4storage[10];
+    rotation.storage[0] = _m4storage[0];
+    rotation.storage[1] = _m4storage[1];
+    rotation.storage[2] = _m4storage[2];
+    rotation.storage[3] = _m4storage[4];
+    rotation.storage[4] = _m4storage[5];
+    rotation.storage[5] = _m4storage[6];
+    rotation.storage[6] = _m4storage[8];
+    rotation.storage[7] = _m4storage[9];
+    rotation.storage[8] = _m4storage[10];
   }
 
   /// Sets the rotation matrix in this homogeneous transformation matrix.
-  void setRotation(Matrix3 r) {
-    final rStorage = r._m3storage;
-    _m4storage[0] = rStorage[0];
-    _m4storage[1] = rStorage[1];
-    _m4storage[2] = rStorage[2];
-    _m4storage[4] = rStorage[3];
-    _m4storage[5] = rStorage[4];
-    _m4storage[6] = rStorage[5];
-    _m4storage[8] = rStorage[6];
-    _m4storage[9] = rStorage[7];
-    _m4storage[10] = rStorage[8];
+  void setRotation(Matrix3 rotation) {
+    _m4storage[0] = rotation.storage[0];
+    _m4storage[1] = rotation.storage[1];
+    _m4storage[2] = rotation.storage[2];
+    _m4storage[4] = rotation.storage[3];
+    _m4storage[5] = rotation.storage[4];
+    _m4storage[6] = rotation.storage[5];
+    _m4storage[8] = rotation.storage[6];
+    _m4storage[9] = rotation.storage[7];
+    _m4storage[10] = rotation.storage[8];
   }
 
   /// Returns the normal matrix from this homogeneous transformation matrix.

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -6,11 +6,9 @@ part of '../../vector_math_64.dart';
 
 /// 2D column vector.
 class Vector2 implements Vector {
-  final Float64List _v2storage;
-
   /// The components of the vector.
   @override
-  Float64List get storage => _v2storage;
+  final Float64List storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector2 a, Vector2 b, Vector2 result) {
@@ -35,28 +33,31 @@ class Vector2 implements Vector {
   }
 
   /// Construct a new vector with the specified values.
-  factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
+  Vector2(double x, double y)
+      : storage = Float64List(2)
+          ..[0] = x
+          ..[1] = y;
 
   /// Initialized with values from [array] starting at [offset].
-  factory Vector2.array(List<double> array, [int offset = 0]) =>
-      Vector2.zero()..copyFromArray(array, offset);
+  Vector2.array(List<double> array, [int offset = 0])
+      : this(array[0 + offset], array[1 + offset]);
 
   /// Zero vector.
-  Vector2.zero() : _v2storage = Float64List(2);
+  Vector2.zero() : storage = Float64List(2);
 
   /// Splat [value] into all lanes of the vector.
-  factory Vector2.all(double value) => Vector2.zero()..splat(value);
+  Vector2.all(double value) : this(value, value);
 
   /// Copy of [other].
-  factory Vector2.copy(Vector2 other) => Vector2.zero()..setFrom(other);
+  Vector2.copy(Vector2 other) : this(other.x, other.y);
 
   /// Constructs Vector2 with a given [Float64List] as [storage].
-  Vector2.fromFloat64List(this._v2storage);
+  Vector2.fromFloat64List(this.storage);
 
   /// Constructs Vector2 with a [storage] that views given [buffer] starting at
-  /// [offset]. [offset] has to be multiple of [Float64List.bytesPerElement].
+  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Vector2.fromBuffer(ByteBuffer buffer, int offset)
-      : _v2storage = Float64List.view(buffer, offset, 2);
+      : storage = Float64List.view(buffer, offset, 2);
 
   /// Generate random vector in the range (0, 0) to (1, 1). You can
   /// optionally pass your own random number generator.
@@ -67,42 +68,42 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    _v2storage[0] = x_;
-    _v2storage[1] = y_;
+    storage[0] = x_;
+    storage[1] = y_;
   }
 
   /// Zero the vector.
   void setZero() {
-    _v2storage[0] = 0.0;
-    _v2storage[1] = 0.0;
+    storage[0] = 0.0;
+    storage[1] = 0.0;
   }
 
   /// Set the values by copying them from [other].
   void setFrom(Vector2 other) {
-    final otherStorage = other._v2storage;
-    _v2storage[1] = otherStorage[1];
-    _v2storage[0] = otherStorage[0];
+    final otherStorage = other.storage;
+    storage[1] = otherStorage[1];
+    storage[0] = otherStorage[0];
   }
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    _v2storage[0] = arg;
-    _v2storage[1] = arg;
+    storage[0] = arg;
+    storage[1] = arg;
   }
 
   /// Returns a printable string
   @override
-  String toString() => '[${_v2storage[0]},${_v2storage[1]}]';
+  String toString() => '[${storage[0]},${storage[1]}]';
 
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
       (other is Vector2) &&
-      (_v2storage[0] == other._v2storage[0]) &&
-      (_v2storage[1] == other._v2storage[1]);
+      (storage[0] == other.storage[0]) &&
+      (storage[1] == other.storage[1]);
 
   @override
-  int get hashCode => Object.hashAll(_v2storage);
+  int get hashCode => Object.hashAll(storage);
 
   /// Negate.
   Vector2 operator -() => clone()..negate();
@@ -120,11 +121,11 @@ class Vector2 implements Vector {
   Vector2 operator *(double scale) => clone()..scale(scale);
 
   /// Access the component of the vector at the index [i].
-  double operator [](int i) => _v2storage[i];
+  double operator [](int i) => storage[i];
 
   /// Set the component of the vector at the index [i].
   void operator []=(int i, double v) {
-    _v2storage[i] = v;
+    storage[i] = v;
   }
 
   /// Set the length of the vector. A negative [value] will change the vectors
@@ -138,8 +139,8 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      _v2storage[0] *= l;
-      _v2storage[1] *= l;
+      storage[0] *= l;
+      storage[1] *= l;
     }
   }
 
@@ -149,8 +150,8 @@ class Vector2 implements Vector {
   /// Length squared.
   double get length2 {
     double sum;
-    sum = _v2storage[0] * _v2storage[0];
-    sum += _v2storage[1] * _v2storage[1];
+    sum = storage[0] * storage[0];
+    sum += storage[1] * storage[1];
     return sum;
   }
 
@@ -161,8 +162,8 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    _v2storage[0] *= d;
-    _v2storage[1] *= d;
+    storage[0] *= d;
+    storage[1] *= d;
     return l;
   }
 
@@ -195,8 +196,8 @@ class Vector2 implements Vector {
 
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -207,8 +208,8 @@ class Vector2 implements Vector {
 
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
-    final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    final otherStorage = other.storage;
+    if (storage[0] == otherStorage[0] && storage[1] == otherStorage[1]) {
       return 0.0;
     }
 
@@ -220,10 +221,10 @@ class Vector2 implements Vector {
 
   /// Inner product.
   double dot(Vector2 other) {
-    final otherStorage = other._v2storage;
+    final otherStorage = other.storage;
     double sum;
-    sum = _v2storage[0] * otherStorage[0];
-    sum += _v2storage[1] * otherStorage[1];
+    sum = storage[0] * otherStorage[0];
+    sum += storage[1] * otherStorage[1];
     return sum;
   }
 
@@ -235,23 +236,23 @@ class Vector2 implements Vector {
   ///
   void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
-    final v0 = _v2storage[0];
-    final v1 = _v2storage[1];
-    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
-    _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    final v0 = storage[0];
+    final v1 = storage[1];
+    storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
   }
 
   /// Cross product.
   double cross(Vector2 other) {
-    final otherStorage = other._v2storage;
-    return _v2storage[0] * otherStorage[1] - _v2storage[1] * otherStorage[0];
+    final otherStorage = other.storage;
+    return storage[0] * otherStorage[1] - storage[1] * otherStorage[0];
   }
 
   /// Rotate this by 90 degrees then scale it.
   ///
   /// Store result in [out]. Return [out].
   Vector2 scaleOrthogonalInto(double scale, Vector2 out) {
-    out.setValues(-scale * _v2storage[1], scale * _v2storage[0]);
+    out.setValues(-scale * storage[1], scale * storage[0]);
     return out;
   }
 
@@ -276,58 +277,58 @@ class Vector2 implements Vector {
   /// True if any component is infinite.
   bool get isInfinite {
     var is_infinite = false;
-    is_infinite = is_infinite || _v2storage[0].isInfinite;
-    is_infinite = is_infinite || _v2storage[1].isInfinite;
+    is_infinite = is_infinite || storage[0].isInfinite;
+    is_infinite = is_infinite || storage[1].isInfinite;
     return is_infinite;
   }
 
   /// True if any component is NaN.
   bool get isNaN {
     var is_nan = false;
-    is_nan = is_nan || _v2storage[0].isNaN;
-    is_nan = is_nan || _v2storage[1].isNaN;
+    is_nan = is_nan || storage[0].isNaN;
+    is_nan = is_nan || storage[1].isNaN;
     return is_nan;
   }
 
   /// Add [arg] to this.
   void add(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0];
-    _v2storage[1] = _v2storage[1] + argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0];
+    storage[1] = storage[1] + argStorage[1];
   }
 
   /// Add [arg] scaled by [factor] to this.
   void addScaled(Vector2 arg, double factor) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] + argStorage[0] * factor;
-    _v2storage[1] = _v2storage[1] + argStorage[1] * factor;
+    final argStorage = arg.storage;
+    storage[0] = storage[0] + argStorage[0] * factor;
+    storage[1] = storage[1] + argStorage[1] * factor;
   }
 
   /// Subtract [arg] from this.
   void sub(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] - argStorage[0];
-    _v2storage[1] = _v2storage[1] - argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] - argStorage[0];
+    storage[1] = storage[1] - argStorage[1];
   }
 
   /// Multiply entries in this with entries in [arg].
   void multiply(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] * argStorage[0];
-    _v2storage[1] = _v2storage[1] * argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] * argStorage[0];
+    storage[1] = storage[1] * argStorage[1];
   }
 
   /// Divide entries in this with entries in [arg].
   void divide(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = _v2storage[0] / argStorage[0];
-    _v2storage[1] = _v2storage[1] / argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = storage[0] / argStorage[0];
+    storage[1] = storage[1] / argStorage[1];
   }
 
   /// Scale this by [arg].
   void scale(double arg) {
-    _v2storage[1] = _v2storage[1] * arg;
-    _v2storage[0] = _v2storage[0] * arg;
+    storage[1] = storage[1] * arg;
+    storage[0] = storage[0] * arg;
   }
 
   /// Return a copy of this scaled by [arg].
@@ -335,58 +336,56 @@ class Vector2 implements Vector {
 
   /// Negate.
   void negate() {
-    _v2storage[1] = -_v2storage[1];
-    _v2storage[0] = -_v2storage[0];
+    storage[1] = -storage[1];
+    storage[0] = -storage[0];
   }
 
   /// Absolute value.
   void absolute() {
-    _v2storage[1] = _v2storage[1].abs();
-    _v2storage[0] = _v2storage[0].abs();
+    storage[1] = storage[1].abs();
+    storage[0] = storage[0].abs();
   }
 
   /// Clamp each entry n in this in the range [min[n]]-[max[n]].
   void clamp(Vector2 min, Vector2 max) {
     final minStorage = min.storage;
     final maxStorage = max.storage;
-    _v2storage[0] =
-        _v2storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
-    _v2storage[1] =
-        _v2storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
+    storage[0] = storage[0].clamp(minStorage[0], maxStorage[0]).toDouble();
+    storage[1] = storage[1].clamp(minStorage[1], maxStorage[1]).toDouble();
   }
 
   /// Clamp entries this in the range [min]-[max].
   void clampScalar(double min, double max) {
-    _v2storage[0] = _v2storage[0].clamp(min, max).toDouble();
-    _v2storage[1] = _v2storage[1].clamp(min, max).toDouble();
+    storage[0] = storage[0].clamp(min, max).toDouble();
+    storage[1] = storage[1].clamp(min, max).toDouble();
   }
 
   /// Floor entries in this.
   void floor() {
-    _v2storage[0] = _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1].floorToDouble();
+    storage[0] = storage[0].floorToDouble();
+    storage[1] = storage[1].floorToDouble();
   }
 
   /// Ceil entries in this.
   void ceil() {
-    _v2storage[0] = _v2storage[0].ceilToDouble();
-    _v2storage[1] = _v2storage[1].ceilToDouble();
+    storage[0] = storage[0].ceilToDouble();
+    storage[1] = storage[1].ceilToDouble();
   }
 
   /// Round entries in this.
   void round() {
-    _v2storage[0] = _v2storage[0].roundToDouble();
-    _v2storage[1] = _v2storage[1].roundToDouble();
+    storage[0] = storage[0].roundToDouble();
+    storage[1] = storage[1].roundToDouble();
   }
 
   /// Round entries in this towards zero.
   void roundToZero() {
-    _v2storage[0] = _v2storage[0] < 0.0
-        ? _v2storage[0].ceilToDouble()
-        : _v2storage[0].floorToDouble();
-    _v2storage[1] = _v2storage[1] < 0.0
-        ? _v2storage[1].ceilToDouble()
-        : _v2storage[1].floorToDouble();
+    storage[0] = storage[0] < 0.0
+        ? storage[0].ceilToDouble()
+        : storage[0].floorToDouble();
+    storage[1] = storage[1] < 0.0
+        ? storage[1].ceilToDouble()
+        : storage[1].floorToDouble();
   }
 
   /// Clone of this.
@@ -394,96 +393,80 @@ class Vector2 implements Vector {
 
   /// Copy this into [arg]. Returns [arg].
   Vector2 copyInto(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    argStorage[1] = _v2storage[1];
-    argStorage[0] = _v2storage[0];
+    final argStorage = arg.storage;
+    argStorage[1] = storage[1];
+    argStorage[0] = storage[0];
     return arg;
   }
 
   /// Copies this into [array] starting at [offset].
   void copyIntoArray(List<double> array, [int offset = 0]) {
-    array[offset + 1] = _v2storage[1];
-    array[offset + 0] = _v2storage[0];
+    array[offset + 1] = storage[1];
+    array[offset + 0] = storage[0];
   }
 
   /// Copies elements from [array] into this starting at [offset].
   void copyFromArray(List<double> array, [int offset = 0]) {
-    _v2storage[1] = array[offset + 1];
-    _v2storage[0] = array[offset + 0];
+    storage[1] = array[offset + 1];
+    storage[0] = array[offset + 0];
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[0] = argStorage[0];
-    _v2storage[1] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[0] = argStorage[0];
+    storage[1] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
-    _v2storage[1] = argStorage[0];
-    _v2storage[0] = argStorage[1];
+    final argStorage = arg.storage;
+    storage[1] = argStorage[0];
+    storage[0] = argStorage[1];
   }
 
   set r(double arg) => x = arg;
   set g(double arg) => y = arg;
   set s(double arg) => x = arg;
   set t(double arg) => y = arg;
-  set x(double arg) => _v2storage[0] = arg;
-  set y(double arg) => _v2storage[1] = arg;
+  set x(double arg) => storage[0] = arg;
+  set y(double arg) => storage[1] = arg;
   set rg(Vector2 arg) => xy = arg;
   set gr(Vector2 arg) => yx = arg;
   set st(Vector2 arg) => xy = arg;
   set ts(Vector2 arg) => yx = arg;
-  Vector2 get xx => Vector2(_v2storage[0], _v2storage[0]);
-  Vector2 get xy => Vector2(_v2storage[0], _v2storage[1]);
-  Vector2 get yx => Vector2(_v2storage[1], _v2storage[0]);
-  Vector2 get yy => Vector2(_v2storage[1], _v2storage[1]);
-  Vector3 get xxx => Vector3(_v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector3 get xxy => Vector3(_v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector3 get xyx => Vector3(_v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector3 get xyy => Vector3(_v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector3 get yxx => Vector3(_v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector3 get yxy => Vector3(_v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector3 get yyx => Vector3(_v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector3 get yyy => Vector3(_v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get xxxx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get xxxy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get xxyx =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get xxyy =>
-      Vector4(_v2storage[0], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get xyxx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get xyxy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get xyyx =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get xyyy =>
-      Vector4(_v2storage[0], _v2storage[1], _v2storage[1], _v2storage[1]);
-  Vector4 get yxxx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[0]);
-  Vector4 get yxxy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[0], _v2storage[1]);
-  Vector4 get yxyx =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[0]);
-  Vector4 get yxyy =>
-      Vector4(_v2storage[1], _v2storage[0], _v2storage[1], _v2storage[1]);
-  Vector4 get yyxx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[0]);
-  Vector4 get yyxy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[0], _v2storage[1]);
-  Vector4 get yyyx =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[0]);
-  Vector4 get yyyy =>
-      Vector4(_v2storage[1], _v2storage[1], _v2storage[1], _v2storage[1]);
+  Vector2 get xx => Vector2(storage[0], storage[0]);
+  Vector2 get xy => Vector2(storage[0], storage[1]);
+  Vector2 get yx => Vector2(storage[1], storage[0]);
+  Vector2 get yy => Vector2(storage[1], storage[1]);
+  Vector3 get xxx => Vector3(storage[0], storage[0], storage[0]);
+  Vector3 get xxy => Vector3(storage[0], storage[0], storage[1]);
+  Vector3 get xyx => Vector3(storage[0], storage[1], storage[0]);
+  Vector3 get xyy => Vector3(storage[0], storage[1], storage[1]);
+  Vector3 get yxx => Vector3(storage[1], storage[0], storage[0]);
+  Vector3 get yxy => Vector3(storage[1], storage[0], storage[1]);
+  Vector3 get yyx => Vector3(storage[1], storage[1], storage[0]);
+  Vector3 get yyy => Vector3(storage[1], storage[1], storage[1]);
+  Vector4 get xxxx => Vector4(storage[0], storage[0], storage[0], storage[0]);
+  Vector4 get xxxy => Vector4(storage[0], storage[0], storage[0], storage[1]);
+  Vector4 get xxyx => Vector4(storage[0], storage[0], storage[1], storage[0]);
+  Vector4 get xxyy => Vector4(storage[0], storage[0], storage[1], storage[1]);
+  Vector4 get xyxx => Vector4(storage[0], storage[1], storage[0], storage[0]);
+  Vector4 get xyxy => Vector4(storage[0], storage[1], storage[0], storage[1]);
+  Vector4 get xyyx => Vector4(storage[0], storage[1], storage[1], storage[0]);
+  Vector4 get xyyy => Vector4(storage[0], storage[1], storage[1], storage[1]);
+  Vector4 get yxxx => Vector4(storage[1], storage[0], storage[0], storage[0]);
+  Vector4 get yxxy => Vector4(storage[1], storage[0], storage[0], storage[1]);
+  Vector4 get yxyx => Vector4(storage[1], storage[0], storage[1], storage[0]);
+  Vector4 get yxyy => Vector4(storage[1], storage[0], storage[1], storage[1]);
+  Vector4 get yyxx => Vector4(storage[1], storage[1], storage[0], storage[0]);
+  Vector4 get yyxy => Vector4(storage[1], storage[1], storage[0], storage[1]);
+  Vector4 get yyyx => Vector4(storage[1], storage[1], storage[1], storage[0]);
+  Vector4 get yyyy => Vector4(storage[1], storage[1], storage[1], storage[1]);
   double get r => x;
   double get g => y;
   double get s => x;
   double get t => y;
-  double get x => _v2storage[0];
-  double get y => _v2storage[1];
+  double get x => storage[0];
+  double get y => storage[1];
   Vector2 get rr => xx;
   Vector2 get rg => xy;
   Vector2 get gr => yx;

--- a/lib/src/vector_math_64/vector3.dart
+++ b/lib/src/vector_math_64/vector3.dart
@@ -555,37 +555,37 @@ class Vector3 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[0] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[1] = argStorage[0];
     _v3storage[2] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v3storage[2] = argStorage[0];
     _v3storage[1] = argStorage[1];
   }

--- a/lib/src/vector_math_64/vector4.dart
+++ b/lib/src/vector_math_64/vector4.dart
@@ -461,73 +461,73 @@ class Vector4 implements Vector {
   }
 
   set xy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set xz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set xw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[0] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set yx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set yz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }
 
   set yw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[1] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set zx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set zy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set zw(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[2] = argStorage[0];
     _v4storage[3] = argStorage[1];
   }
 
   set wx(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[0] = argStorage[1];
   }
 
   set wy(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[1] = argStorage[1];
   }
 
   set wz(Vector2 arg) {
-    final argStorage = arg._v2storage;
+    final argStorage = arg.storage;
     _v4storage[3] = argStorage[0];
     _v4storage[2] = argStorage[1];
   }


### PR DESCRIPTION
This PR:

 - Does the same as #286 but for Matrix3
 - Removes all factory constructors (except Matrix2.rotation)
 - Simplifies many calculations

Since this is based on the branch for #286 that should be merged first and then this branch should be updated.