### PR TITLE
Add operator== to Quaternion

### DIFF
--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -394,6 +394,18 @@ class Quaternion {
         w * ow - x * ox - y * oy - z * oz);
   }
 
+  /// Check if two quaternions are the same.
+  @override
+  bool operator ==(Object other) =>
+      (other is Quaternion) &&
+      (_qStorage[0] == other._qStorage[0]) &&
+      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[2] == other._qStorage[2]) &&
+      (_qStorage[3] == other._qStorage[3]);
+
+  @override
+  int get hashCode => Object.hashAll(_qStorage);
+
   /// Returns copy of this + [other].
   Quaternion operator +(Quaternion other) => clone()..add(other);
 

--- a/lib/src/vector_math/quaternion.dart
+++ b/lib/src/vector_math/quaternion.dart
@@ -398,10 +398,10 @@ class Quaternion {
   @override
   bool operator ==(Object other) =>
       (other is Quaternion) &&
-      (_qStorage[0] == other._qStorage[0]) &&
-      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[3] == other._qStorage[3]) &&
       (_qStorage[2] == other._qStorage[2]) &&
-      (_qStorage[3] == other._qStorage[3]);
+      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[0] == other._qStorage[0]);
 
   @override
   int get hashCode => Object.hashAll(_qStorage);

--- a/lib/src/vector_math_64/quaternion.dart
+++ b/lib/src/vector_math_64/quaternion.dart
@@ -394,6 +394,18 @@ class Quaternion {
         w * ow - x * ox - y * oy - z * oz);
   }
 
+  /// Check if two quaternions are the same.
+  @override
+  bool operator ==(Object other) =>
+      (other is Quaternion) &&
+      (_qStorage[0] == other._qStorage[0]) &&
+      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[2] == other._qStorage[2]) &&
+      (_qStorage[3] == other._qStorage[3]);
+
+  @override
+  int get hashCode => Object.hashAll(_qStorage);
+
   /// Returns copy of this + [other].
   Quaternion operator +(Quaternion other) => clone()..add(other);
 

--- a/lib/src/vector_math_64/quaternion.dart
+++ b/lib/src/vector_math_64/quaternion.dart
@@ -398,10 +398,10 @@ class Quaternion {
   @override
   bool operator ==(Object other) =>
       (other is Quaternion) &&
-      (_qStorage[0] == other._qStorage[0]) &&
-      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[3] == other._qStorage[3]) &&
       (_qStorage[2] == other._qStorage[2]) &&
-      (_qStorage[3] == other._qStorage[3]);
+      (_qStorage[1] == other._qStorage[1]) &&
+      (_qStorage[0] == other._qStorage[0]);
 
   @override
   int get hashCode => Object.hashAll(_qStorage);


### PR DESCRIPTION
Adds an operator== to Quaternion so that two instances of quaternions can be evaluated for equality.

I didn't see a unit test for this comparable functionality in Vector3, so assumed it's trivial enough, but can add one if desired.