### PR TITLE
fix: Revert Vector2 constructor changes

### DIFF
--- a/lib/src/vector_math/vector2.dart
+++ b/lib/src/vector_math/vector2.dart
@@ -35,25 +35,20 @@ class Vector2 implements Vector {
   }
 
   /// Construct a new vector with the specified values.
-  Vector2(double x, double y)
-      : _v2storage = Float32List(2)
-          ..[1] = y
-          ..[0] = x;
+  factory Vector2(double x, double y) => Vector2.zero()..setValues(x, y);
 
   /// Initialized with values from [array] starting at [offset].
-  Vector2.array(List<double> array, [int offset = 0])
-      : _v2storage = Float32List(2)
-          ..[1] = array[1 + offset]
-          ..[0] = array[0 + offset];
+  factory Vector2.array(List<double> array, [int offset = 0]) =>
+      Vector2.zero()..copyFromArray(array, offset);
 
   /// Zero vector.
   Vector2.zero() : _v2storage = Float32List(2);
 
   /// Splat [value] into all lanes of the vector.
-  Vector2.all(double value) : this(value, value);
+  factory Vector2.all(double value) => Vector2.zero()..splat(value);
 
   /// Copy of [other].
-  Vector2.copy(Vector2 other) : this(other.x, other.y);
+  factory Vector2.copy(Vector2 other) => Vector2.zero()..setFrom(other);
 
   /// Constructs Vector2 with a given [Float32List] as [storage].
   Vector2.fromFloat32List(this._v2storage);

--- a/lib/src/vector_math_64/vector2.dart
+++ b/lib/src/vector_math_64/vector2.dart
@@ -67,14 +67,14 @@ class Vector2 implements Vector {
 
   /// Set the values of the vector.
   void setValues(double x_, double y_) {
-    _v2storage[0] = x_;
     _v2storage[1] = y_;
+    _v2storage[0] = x_;
   }
 
   /// Zero the vector.
   void setZero() {
-    _v2storage[0] = 0.0;
     _v2storage[1] = 0.0;
+    _v2storage[0] = 0.0;
   }
 
   /// Set the values by copying them from [other].
@@ -86,8 +86,8 @@ class Vector2 implements Vector {
 
   /// Splat [arg] into all lanes of the vector.
   void splat(double arg) {
-    _v2storage[0] = arg;
     _v2storage[1] = arg;
+    _v2storage[0] = arg;
   }
 
   /// Returns a printable string
@@ -97,9 +97,9 @@ class Vector2 implements Vector {
   /// Check if two vectors are the same.
   @override
   bool operator ==(Object other) =>
-      (other is Vector2) &&
-      (_v2storage[0] == other._v2storage[0]) &&
-      (_v2storage[1] == other._v2storage[1]);
+      other is Vector2 &&
+      _v2storage[1] == other._v2storage[1] &&
+      _v2storage[0] == other._v2storage[0];
 
   @override
   int get hashCode => Object.hashAll(_v2storage);
@@ -138,21 +138,17 @@ class Vector2 implements Vector {
         return;
       }
       l = value / l;
-      _v2storage[0] *= l;
       _v2storage[1] *= l;
+      _v2storage[0] *= l;
     }
   }
 
-  /// Length.
+  /// The length of the vector.
   double get length => math.sqrt(length2);
 
-  /// Length squared.
-  double get length2 {
-    double sum;
-    sum = _v2storage[0] * _v2storage[0];
-    sum += _v2storage[1] * _v2storage[1];
-    return sum;
-  }
+  /// The squared length of the vector.
+  double get length2 =>
+      _v2storage[1] * _v2storage[1] + _v2storage[0] * _v2storage[0];
 
   /// Normalize this.
   double normalize() {
@@ -161,14 +157,13 @@ class Vector2 implements Vector {
       return 0.0;
     }
     final d = 1.0 / l;
-    _v2storage[0] *= d;
     _v2storage[1] *= d;
+    _v2storage[0] *= d;
     return l;
   }
 
   /// Normalize this. Returns length of vector before normalization.
-  /// DEPRECATED: Use [normalize].
-  @Deprecated('Use normalize() insteaed.')
+  @Deprecated('Use normalize() instead.')
   double normalizeLength() => normalize();
 
   /// Normalized copy of this.
@@ -196,7 +191,7 @@ class Vector2 implements Vector {
   /// Returns the angle between this vector and [other] in radians.
   double angleTo(Vector2 other) {
     final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    if (_v2storage[1] == otherStorage[1] && _v2storage[0] == otherStorage[0]) {
       return 0.0;
     }
 
@@ -208,7 +203,7 @@ class Vector2 implements Vector {
   /// Returns the signed angle between this and [other] in radians.
   double angleToSigned(Vector2 other) {
     final otherStorage = other._v2storage;
-    if (_v2storage[0] == otherStorage[0] && _v2storage[1] == otherStorage[1]) {
+    if (_v2storage[1] == otherStorage[1] && _v2storage[0] == otherStorage[0]) {
       return 0.0;
     }
 
@@ -221,13 +216,9 @@ class Vector2 implements Vector {
   /// Inner product.
   double dot(Vector2 other) {
     final otherStorage = other._v2storage;
-    double sum;
-    sum = _v2storage[0] * otherStorage[0];
-    sum += _v2storage[1] * otherStorage[1];
-    return sum;
+    return _v2storage[1] * otherStorage[1] + _v2storage[0] * otherStorage[0];
   }
 
-  ///
   /// Transforms this into the product of this as a row vector,
   /// postmultiplied by matrix, [arg].
   /// If [arg] is a rotation matrix, this is a computational shortcut for
@@ -235,10 +226,10 @@ class Vector2 implements Vector {
   ///
   void postmultiply(Matrix2 arg) {
     final argStorage = arg.storage;
-    final v0 = _v2storage[0];
     final v1 = _v2storage[1];
-    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
+    final v0 = _v2storage[0];
     _v2storage[1] = v0 * argStorage[2] + v1 * argStorage[3];
+    _v2storage[0] = v0 * argStorage[0] + v1 * argStorage[1];
   }
 
   /// Cross product.
@@ -257,37 +248,30 @@ class Vector2 implements Vector {
 
   /// Reflect this.
   void reflect(Vector2 normal) {
-    sub(normal.scaled(2.0 * normal.dot(this)));
+    final dotProduct = normal.dot(this) * 2;
+    _v2storage[1] -= normal._v2storage[1] * dotProduct;
+    _v2storage[0] -= normal._v2storage[0] * dotProduct;
   }
 
   /// Reflected copy of this.
   Vector2 reflected(Vector2 normal) => clone()..reflect(normal);
 
   /// Relative error between this and [correct]
-  double relativeError(Vector2 correct) {
-    final correct_norm = correct.length;
-    final diff_norm = (this - correct).length;
-    return diff_norm / correct_norm;
-  }
+  double relativeError(Vector2 correct) =>
+      absoluteError(correct) / correct.length;
 
   /// Absolute error between this and [correct]
-  double absoluteError(Vector2 correct) => (this - correct).length;
+  double absoluteError(Vector2 correct) {
+    final yDiff = _v2storage[1] - correct._v2storage[1];
+    final xDiff = _v2storage[0] - correct._v2storage[0];
+    return math.sqrt(xDiff * xDiff + yDiff * yDiff);
+  }
 
   /// True if any component is infinite.
-  bool get isInfinite {
-    var is_infinite = false;
-    is_infinite = is_infinite || _v2storage[0].isInfinite;
-    is_infinite = is_infinite || _v2storage[1].isInfinite;
-    return is_infinite;
-  }
+  bool get isInfinite => _v2storage[1].isInfinite || _v2storage[0].isInfinite;
 
   /// True if any component is NaN.
-  bool get isNaN {
-    var is_nan = false;
-    is_nan = is_nan || _v2storage[0].isNaN;
-    is_nan = is_nan || _v2storage[1].isNaN;
-    return is_nan;
-  }
+  bool get isNaN => _v2storage[1].isNaN || _v2storage[0].isNaN;
 
   /// Add [arg] to this.
   void add(Vector2 arg) {


### PR DESCRIPTION
This reverts back the named constructors of Vector2 to factory constructors so that we can continue with the the Vector3 and Vector4 changes in #294 and #295.

Ping @rakudrama and @johnmccutchan, the other PRs are also updated to remove the named constructors.