### PR TITLE
Update README.md to show how to use vector_math_64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ void main() {
 }
 ```
 
+8\. Use 64bit float precision (instead of 32bit)
+
+```dart
+// Use different import statement.
+// Which is a drop-in replacement for 'package:vector_math/vector_math.dart'
+import 'package:vector_math/vector_math_64.dart';
+void main() {
+  // Types work the same, but using 64 bit storage.
+  Vector3 x = Vector3.zero(); 
+  Matrix4 m = Matrix4.identity();
+}
+```
+
 ## Development
 
 To run the unit tests:


### PR DESCRIPTION
I was originally confused which to import, 'package:vector_math/vector_math.dart' or 'package:vector_math/vector_math_64.dart'. After reading the code, I figured a minor update to the readme might be helpful.

If there was somewhere more appropriate, or a better way to express this I'm happy to make changes.