### PR TITLE
Resolve Inconsistency in Matrix3 and Matrix4 `rotateY` Implementations

### DIFF
--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -556,11 +556,11 @@ class Matrix3 {
     final s = math.sin(radians);
     _m3storage[0] = c;
     _m3storage[1] = 0.0;
-    _m3storage[2] = s;
+    _m3storage[2] = -s;
     _m3storage[3] = 0.0;
     _m3storage[4] = 1.0;
     _m3storage[5] = 0.0;
-    _m3storage[6] = -s;
+    _m3storage[6] = s;
     _m3storage[7] = 0.0;
     _m3storage[8] = c;
   }

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -556,11 +556,11 @@ class Matrix3 {
     final s = math.sin(radians);
     _m3storage[0] = c;
     _m3storage[1] = 0.0;
-    _m3storage[2] = s;
+    _m3storage[2] = -s;
     _m3storage[3] = 0.0;
     _m3storage[4] = 1.0;
     _m3storage[5] = 0.0;
-    _m3storage[6] = -s;
+    _m3storage[6] = s;
     _m3storage[7] = 0.0;
     _m3storage[8] = c;
   }

--- a/test/matrix3_test.dart
+++ b/test/matrix3_test.dart
@@ -194,9 +194,30 @@ void testMatrix3Transform() {
 
   relativeTest(rotX.transformed(input), input);
   relativeTest(rotY.transformed(input),
-      Vector3(1.0 / math.sqrt(2.0), 0.0, 1.0 / math.sqrt(2.0)));
+      Vector3(1.0 / math.sqrt(2.0), 0.0, -1.0 / math.sqrt(2.0)));
   relativeTest(rotZ.transformed(input),
       Vector3(1.0 / math.sqrt(2.0), 1.0 / math.sqrt(2.0), 0.0));
+}
+
+void testMatrix3RotationX() {
+  final rotX = Matrix3.rotationX(math.pi / 2);
+  final input = Vector3(0.0, 1.0, 0.0);
+
+  relativeTest(rotX.transformed(input), Vector3(0.0, 0.0, 1.0));
+}
+
+void testMatrix3RotationY() {
+  final rotY = Matrix3.rotationY(math.pi / 2);
+  final input = Vector3(0.0, 0.0, 1.0);
+
+  relativeTest(rotY.transformed(input), Vector3(1.0, 0.0, 0.0));
+}
+
+void testMatrix3RotationZ() {
+  final rotZ = Matrix3.rotationZ(math.pi / 2);
+  final input = Vector3(1.0, 0.0, 0.0);
+
+  relativeTest(rotZ.transformed(input), Vector3(0.0, 1.0, 0.0));
 }
 
 void testMatrix3Transform2() {
@@ -334,6 +355,9 @@ void main() {
     test('transform 2D', testMatrix3Transform2);
     test('rotation 2D', testMatrix3AbsoluteRotate2);
     test('transform', testMatrix3Transform);
+    test('rotation 3D x', testMatrix3RotationX);
+    test('rotation 3D y', testMatrix3RotationY);
+    test('rotation 3D z', testMatrix3RotationZ);
     test('constructor', testMatrix3ConstructorCopy);
     test('inversion', testMatrix3Inversion);
     test('dot product', testMatrix3Dot);

--- a/test/obb3_test.dart
+++ b/test/obb3_test.dart
@@ -79,7 +79,7 @@ void testRotate() {
     ..center.setValues(0.0, 0.0, 0.0)
     ..halfExtents.setValues(5.0, 5.0, 5.0);
   final corner = Vector3.zero();
-  final matrix = Matrix3.rotationY(radians(45.0));
+  final matrix = Matrix3.rotationY(radians(-45.0));
 
   a.rotate(matrix);
 


### PR DESCRIPTION
This PR addresses the issues highlighted in #261 and is related to the discussions in #262 and #300, as well as the historical context provided by #69.

In reference to the conversation in [#262](https://github.com/google/vector_math.dart/pull/262#issuecomment-1651969704), two primary concerns were identified:

1. The change introduced test failures.
2. There was an inconsistency between the `rotateY` methods in the `Matrix3` and `Matrix4` classes.

Here's a summary of the remedial actions taken in this PR:

This PR is similar to #262. The only difference is that this PR also includes a negated rotation angle in the `obb3` test.

For issue (1), the test expectations have been updated to reflect the correct signs, ensuring that all tests now pass.

Regarding issue (2), upon further investigation, it was found that the `Matrix4` class already had the correct implementation since August 23, 2014. However, the `Matrix3` class has not been updated to match this, leading to a longstanding inconsistency between the two. This PR rectifies the `Matrix3` `rotateY` method to align with the `Matrix4` implementation, bringing them into consistency.

```dart
  // Matrix3
  /// Turns the matrix into a rotation of [radians] around Y
  void setRotationY(double radians) {
    final c = math.cos(radians);
    final s = math.sin(radians);
    _m3storage[0] = c;
    _m3storage[1] = 0.0;
    _m3storage[2] = -s;
    _m3storage[3] = 0.0;
    _m3storage[4] = 1.0;
    _m3storage[5] = 0.0;
    _m3storage[6] = s;
    _m3storage[7] = 0.0;
    _m3storage[8] = c;
  }
  
  // Matrix4
  /// Sets the upper 3x3 to a rotation of [radians] around Y
  void setRotationY(double radians) {
    final c = math.cos(radians);
    final s = math.sin(radians);
    _m4storage[0] = c;
    _m4storage[1] = 0.0;
    _m4storage[2] = -s;
    _m4storage[4] = 0.0;
    _m4storage[5] = 1.0;
    _m4storage[6] = 0.0;
    _m4storage[8] = s;
    _m4storage[9] = 0.0;
    _m4storage[10] = c;
    _m4storage[3] = 0.0;
    _m4storage[7] = 0.0;
    _m4storage[11] = 0.0;
  }
```

This PR is similar to #262. The only difference is that this PR also includes a negated rotation angle in the `obb3` test.

By merging this PR, we will resolve the inconsistencies and adhere to the mathematical definitions of rotation matrices, as expected by the users of the `vector_math.dart` library.

I look forward to your feedback and to further improving the library.