### PR TITLE
Update dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    labels:
-      - autosubmit
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
- no longer add the `autosubmit` label to dependabot created PRs (this repo isn't managed by the autosubmit bot)