### PR TITLE
prep for publishing 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.5-wip
+## 2.1.5
 
 - Fixed `operator -()` of Quaternion (Contributed by tlserver)
 - Fixed `Matrix3.rotationY` direction (Contributed by tlserver, moritzblume)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.1.5-wip
+version: 2.1.5
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 


### PR DESCRIPTION
- prep. for publishing 2.1.5

This captures the ~3 unpublished items in the [changelog](https://github.com/google/vector_math.dart/blob/master/CHANGELOG.md):

- Fixed operator -() of Quaternion (Contributed by tlserver)
- Fixed Matrix3.rotationY direction (Contributed by tlserver, moritzblume)
- Added an operator== to Quaternion so that two instances of quaternions can be evaluated for equality.

@johnmccutchan - I assume these changes are reasonable to publish?
