### PR TITLE
Improve performance of functions with dynamic arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-wip
+## 2.2.0-wip
 
 - Performance of functions that take `dynamic` arguments improved.
 - Most of the members that take `dynamic` arguments are deprecated. New members

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,17 +21,6 @@
     Instead use: `Matrix4.scaledByDouble`, `Matrix4.scaledByVector3`,
     `Matrix4.scaledByVector4`.
 
-- New `Matrix4` members added with precise argument types (instead of
-  `dynamic`), with better performance:
-  - `Matrix4.scaleByDouble`, `Matrix4.scaleByVector3`, `Matrix4.scaleByVector4`
-    as faster `Matrix4.scale`.
-  - `Matrix4.translateByDouble`, `Matrix4.translateByVector3`,
-    `Matrix4.translateByVector4` as faster `Matrix4.translate`.
-  - `Matrix4.leftTranslateByDouble`, `Matrix4.leftTranslateByVector3`,
-    `Matrix4.leftTranslateByVector4` as faster `Matrix4.leftTranslate`.
-  These new functions should be preferred over the old ones when the argument
-  type is known at a call site.
-
 ## 2.1.5
 
 - Fixed `operator -()` of Quaternion (Contributed by tlserver)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.2.0-wip
+
+- Performance of functions that take `dynamic` arguments improved.
+- New `Matrix4` members added with precise argument types (instead of
+  `dynamic`), with better performance:
+  - `Matrix4.scaleByDouble`, `Matrix4.scaleByVector3`, `Matrix4.scaleByVector4`
+    as faster `Matrix4.scale`.
+  - `Matrix4.translateByDouble`, `Matrix4.translateByVector3`,
+    `Matrix4.translateByVector4` as faster `Matrix4.translate`.
+  - `Matrix4.leftTranslateByDouble`, `Matrix4.leftTranslateByVector3`,
+    `Matrix4.leftTranslateByVector4` as faster `Matrix4.leftTranslate`.
+  These new functions should be preferred over the old ones when the argument
+  type is known at a call site.
+
 ## 2.1.5
 
 - Fixed `operator -()` of Quaternion (Contributed by tlserver)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 ## 2.2.0-wip
 
 - Performance of functions that take `dynamic` arguments improved.
+- Most of the members that take `dynamic` arguments are deprecated. New members
+  with non-`dynamic` arguments added.
+
+  Deprecated members:
+  - `Matrix4.translate`
+    Instead use: `Matrix4.translateByDouble`, `Matrix4.translateByVector3`,
+    `Matrix4.translateByVector4`.
+
+  - `Matrix4.leftTranslate`
+    Instead use: `Matrix4.leftTranslateByDouble`,
+    `Matrix4.leftTranslateByVector3`, `Matrix4.leftTranslateByVector4`.
+
+  - `Matrix4.scale`
+    Instead use: `Matrix4.scaleByDouble`, `Matrix4.scaleByVector3`,
+    `Matrix4.scaleByVector4`.
+
+  - `Matrix4.scaled`
+    Instead use: `Matrix4.scaledByDouble`, `Matrix4.scaledByVector3`,
+    `Matrix4.scaledByVector4`.
+
 - New `Matrix4` members added with precise argument types (instead of
   `dynamic`), with better performance:
   - `Matrix4.scaleByDouble`, `Matrix4.scaleByVector3`, `Matrix4.scaleByVector4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-wip
+## 3.0.0-wip
 
 - Performance of functions that take `dynamic` arguments improved.
 - Most of the members that take `dynamic` arguments are deprecated. New members

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,22 @@
 
   Deprecated members:
   - `Matrix4.translate`
+
     Instead use: `Matrix4.translateByDouble`, `Matrix4.translateByVector3`,
     `Matrix4.translateByVector4`.
 
   - `Matrix4.leftTranslate`
+
     Instead use: `Matrix4.leftTranslateByDouble`,
     `Matrix4.leftTranslateByVector3`, `Matrix4.leftTranslateByVector4`.
 
   - `Matrix4.scale`
+
     Instead use: `Matrix4.scaleByDouble`, `Matrix4.scaleByVector3`,
     `Matrix4.scaleByVector4`.
 
   - `Matrix4.scaled`
+
     Instead use: `Matrix4.scaledByDouble`, `Matrix4.scaledByVector3`,
     `Matrix4.scaledByVector4`.
 

--- a/benchmark/matrix_bench.dart
+++ b/benchmark/matrix_bench.dart
@@ -393,14 +393,14 @@ class Matrix4TranslateByDoubleBenchmark extends BenchmarkBase {
   void setup() {
     for (var i = 0; i < 10; i++) {
       temp.translateByDouble(
-          i.toDouble(), (i * 10).toDouble(), (i * 5).toDouble());
+          i.toDouble(), (i * 10).toDouble(), (i * 5).toDouble(), 1.0);
     }
   }
 
   @override
   void run() {
     for (var i = 0; i < 100; i++) {
-      temp.translateByDouble(10.0, 20.0, 30.0);
+      temp.translateByDouble(10.0, 20.0, 30.0, 1.0);
     }
   }
 }

--- a/benchmark/matrix_bench.dart
+++ b/benchmark/matrix_bench.dart
@@ -321,6 +321,148 @@ class Matrix3TransposeMultiplyBenchmark extends BenchmarkBase {
   }
 }
 
+class Matrix4TranslateByDoubleGenericBenchmark extends BenchmarkBase {
+  Matrix4TranslateByDoubleGenericBenchmark()
+      : super('Matrix4.translateByDoubleGeneric');
+
+  final temp = Matrix4.zero()..setIdentity();
+
+  static void main() {
+    Matrix4TranslateByDoubleGenericBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translate(10.0, 20.0, 30.0);
+    }
+  }
+}
+
+class Matrix4TranslateByVector3GenericBenchmark extends BenchmarkBase {
+  Matrix4TranslateByVector3GenericBenchmark()
+      : super('Matrix4.translateByVector3Generic');
+
+  final temp = Matrix4.zero()..setIdentity();
+  final vec = Vector3(10.0, 20.0, 30.0);
+
+  static void main() {
+    Matrix4TranslateByVector3GenericBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translate(vec);
+    }
+  }
+}
+
+class Matrix4TranslateByVector4GenericBenchmark extends BenchmarkBase {
+  Matrix4TranslateByVector4GenericBenchmark()
+      : super('Matrix4.translateByVector4Generic');
+
+  final temp = Matrix4.zero()..setIdentity();
+  final vec = Vector4(10.0, 20.0, 30.0, 40.0);
+
+  static void main() {
+    Matrix4TranslateByVector4GenericBenchmark().report();
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translate(vec);
+    }
+  }
+}
+
+class Matrix4TranslateByDoubleBenchmark extends BenchmarkBase {
+  Matrix4TranslateByDoubleBenchmark() : super('Matrix4.translateByDouble');
+
+  final temp = Matrix4.zero()..setIdentity();
+
+  static void main() {
+    Matrix4TranslateByDoubleBenchmark().report();
+  }
+
+  // Call the benchmarked method with random arguments to make sure TFA won't
+  // specialize it based on the arguments passed and wasm-opt won't inline it,
+  // for fair comparison with the generic case.
+  @override
+  void setup() {
+    for (var i = 0; i < 10; i++) {
+      temp.translateByDouble(
+          i.toDouble(), (i * 10).toDouble(), (i * 5).toDouble());
+    }
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translateByDouble(10.0, 20.0, 30.0);
+    }
+  }
+}
+
+class Matrix4TranslateByVector3Benchmark extends BenchmarkBase {
+  Matrix4TranslateByVector3Benchmark() : super('Matrix4.translateByVector3');
+
+  final temp = Matrix4.zero()..setIdentity();
+  final vec = Vector3(10.0, 20.0, 30.0);
+
+  static void main() {
+    Matrix4TranslateByVector3Benchmark().report();
+  }
+
+  // Call the benchmarked method with random arguments to make sure TFA won't
+  // specialize it based on the arguments passed and wasm-opt won't inline it,
+  // for fair comparison with the generic case.
+  @override
+  void setup() {
+    for (var i = 0; i < 10; i++) {
+      temp.translateByVector3(
+          Vector3(i.toDouble(), (i * 10).toDouble(), (i * 5).toDouble()));
+    }
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translateByVector3(vec);
+    }
+  }
+}
+
+class Matrix4TranslateByVector4Benchmark extends BenchmarkBase {
+  Matrix4TranslateByVector4Benchmark() : super('Matrix4.translateByVector4');
+
+  final temp = Matrix4.zero()..setIdentity();
+  final vec = Vector4(10.0, 20.0, 30.0, 40.0);
+
+  static void main() {
+    Matrix4TranslateByVector4Benchmark().report();
+  }
+
+  // Call the benchmarked method with random arguments to make sure TFA won't
+  // specialize it based on the arguments passed and wasm-opt won't inline it,
+  // for fair comparison with the generic case.
+  @override
+  void setup() {
+    for (var i = 0; i < 10; i++) {
+      temp.translateByVector4(Vector4(i.toDouble(), (i * 10).toDouble(),
+          (i * 5).toDouble(), (i * 20).toDouble()));
+    }
+  }
+
+  @override
+  void run() {
+    for (var i = 0; i < 100; i++) {
+      temp.translateByVector4(vec);
+    }
+  }
+}
+
 void main() {
   MatrixMultiplyBenchmark.main();
   SIMDMatrixMultiplyBenchmark.main();
@@ -335,4 +477,10 @@ void main() {
   Matrix3TransformVector3Benchmark.main();
   Matrix3TransformVector2Benchmark.main();
   Matrix3TransposeMultiplyBenchmark.main();
+  Matrix4TranslateByDoubleGenericBenchmark.main();
+  Matrix4TranslateByVector3GenericBenchmark.main();
+  Matrix4TranslateByVector4GenericBenchmark.main();
+  Matrix4TranslateByDoubleBenchmark.main();
+  Matrix4TranslateByVector3Benchmark.main();
+  Matrix4TranslateByVector4Benchmark.main();
 }

--- a/benchmark/matrix_bench.dart
+++ b/benchmark/matrix_bench.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:math' as math;
 import 'dart:typed_data';
 

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -215,6 +215,8 @@ class Matrix2 {
   }
 
   /// Returns a new vector or matrix by multiplying this with [arg].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   dynamic operator *(dynamic arg) {
     if (arg is double) {
       return scaled(arg);

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -219,17 +219,17 @@ class Matrix2 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector2) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Matrix2) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math/matrix2.dart
+++ b/lib/src/vector_math/matrix2.dart
@@ -217,17 +217,19 @@ class Matrix2 {
   /// Returns a new vector or matrix by multiplying this with [arg].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector2) {
+      value = transformed(arg);
+    } else if (arg is Matrix2) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector2) {
-      return transformed(arg);
-    }
-    if (arg is Matrix2) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -328,17 +328,19 @@ class Matrix3 {
   /// Returns a new vector or matrix by multiplying this with [arg].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector3) {
+      value = transformed(arg);
+    } else if (arg is Matrix3) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector3) {
-      return transformed(arg);
-    }
-    if (arg is Matrix3) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -326,6 +326,8 @@ class Matrix3 {
   }
 
   /// Returns a new vector or matrix by multiplying this with [arg].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   dynamic operator *(dynamic arg) {
     if (arg is double) {
       return scaled(arg);

--- a/lib/src/vector_math/matrix3.dart
+++ b/lib/src/vector_math/matrix3.dart
@@ -330,17 +330,17 @@ class Matrix3 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector3) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Matrix3) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -461,7 +461,7 @@ class Matrix4 {
   void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
-    this.scale(scale);
+    scaleByVector3(scale);
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
@@ -642,7 +642,7 @@ class Matrix4 {
   /// [arg] should be a [double] (to scale), [Vector4] (to transform), [Vector3]
   /// (to transform), or [Matrix4] (to multiply).
   ///
-  /// If you know the argument type in a call site, prefer [scaled],
+  /// If you know the argument type in a call site, prefer [scaledByDouble],
   /// [transformed], [transformed3], or [multiplied] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
@@ -650,7 +650,7 @@ class Matrix4 {
   dynamic operator *(dynamic arg) {
     final Object result;
     if (arg is double) {
-      result = scaled(arg);
+      result = scaledByDouble(arg, arg, arg, 1.0);
     } else if (arg is Vector4) {
       result = transformed(arg);
     } else if (arg is Vector3) {
@@ -676,6 +676,8 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use translateByVector3, translateByVector4, '
+      'or translateByDouble instead')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       translateByVector3(x);
@@ -743,6 +745,8 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use leftTranslateByVector3, leftTranslateByVector4, '
+      'or leftTranslateByDouble instead')
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       leftTranslateByVector3(x);
@@ -923,59 +927,24 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use scaleByVector3, scaleByVector4, or scaleByDouble instead')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);
     } else if (x is Vector4) {
       scaleByVector4(x);
     } else if (x is double) {
-      scaleByDouble(x, y ?? x, z ?? x);
+      scaleByDouble(x, y ?? x, z ?? x, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Scale this matrix.
-  void scaleByDouble(double sx, double sy, double sz) {
-    _m4storage[0] *= sx;
-    _m4storage[1] *= sx;
-    _m4storage[2] *= sx;
-    _m4storage[3] *= sx;
-    _m4storage[4] *= sy;
-    _m4storage[5] *= sy;
-    _m4storage[6] *= sy;
-    _m4storage[7] *= sy;
-    _m4storage[8] *= sz;
-    _m4storage[9] *= sz;
-    _m4storage[10] *= sz;
-    _m4storage[11] *= sz;
-  }
-
-  /// Scale this matrix.
-  void scaleByVector3(Vector3 v3) {
-    final sx = v3.x;
-    final sy = v3.y;
-    final sz = v3.z;
-    _m4storage[0] *= sx;
-    _m4storage[1] *= sx;
-    _m4storage[2] *= sx;
-    _m4storage[3] *= sx;
-    _m4storage[4] *= sy;
-    _m4storage[5] *= sy;
-    _m4storage[6] *= sy;
-    _m4storage[7] *= sy;
-    _m4storage[8] *= sz;
-    _m4storage[9] *= sz;
-    _m4storage[10] *= sz;
-    _m4storage[11] *= sz;
-  }
-
-  /// Scale this matrix.
-  void scaleByVector4(Vector4 v4) {
-    final sx = v4.x;
-    final sy = v4.y;
-    final sz = v4.z;
-    final sw = v4.w;
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByDouble(double sx, double sy, double sz, double sw) {
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -994,12 +963,44 @@ class Matrix4 {
     _m4storage[15] *= sw;
   }
 
+  /// Scale this matrix.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByVector3(Vector3 v3) => scaleByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Scale this matrix.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByVector4(Vector4 v4) => scaleByDouble(v4.x, v4.y, v4.z, v4.w);
+
   /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
   /// [z].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use scaledByVector3, scaledByVector4, or scaledByDouble instead')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
+
+  /// Create a copy of this scaled by [x], [y], [z], and [t].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByDouble(double x, double y, double z, double t) =>
+      clone()..scaleByDouble(x, y, z, t);
+
+  /// Create a copy of this scaled by a [Vector3].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByVector3(Vector3 v3) => clone()..scaleByVector3(v3);
+
+  /// Create a copy of this scaled by a [Vector4].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByVector4(Vector4 v4) => clone()..scaleByVector4(v4);
 
   /// Zeros this.
   void setZero() {

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -648,19 +648,19 @@ class Matrix4 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector4) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Vector3) {
-      value = transformed3(arg);
+      result = transformed3(arg);
     } else if (arg is Matrix4) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -690,7 +690,7 @@ class Matrix4 {
     }
   }
 
-  /// Translate this matrix by x, y, z.
+  /// Translate this matrix by x, y, z, w.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -803,24 +803,28 @@ class Matrix4 {
   /// Multiply this by a translation from the left.
   void leftTranslateByDouble(double tx, double ty, double tz) {
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
   }
 
   /// Multiply this by a translation from the left.
@@ -830,24 +834,28 @@ class Matrix4 {
     final tz = v3.z;
 
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
   }
 
   /// Multiply this by a translation from the left.
@@ -858,28 +866,32 @@ class Matrix4 {
     final tw = v4.w;
 
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
-    _m4storage[3] = tw * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
+    _m4storage[3] = tw * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
-    _m4storage[7] = tw * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
+    _m4storage[7] = tw * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
-    _m4storage[11] = tw * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
+    _m4storage[11] = tw * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
-    _m4storage[15] = tw * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
+    _m4storage[15] = tw * r4;
   }
 
   /// Rotate this [angle] radians around [axis]

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -703,6 +703,84 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
+  void translateByDouble(double tx, [double ty = 0.0, double tz = 0.0]) {
+    final tw = 1.0;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
+  void translateByVector3(Vector3 v3) {
+    final tx = v3.x;
+    final ty = v3.y;
+    final tz = v3.z;
+    final tw = 1.0;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
+  void translateByVector4(Vector4 v4) {
+    final tx = v4.x;
+    final ty = v4.y;
+    final tz = v4.z;
+    final tw = v4.w;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
   /// Multiply this by a translation from the left.
   /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -982,27 +982,63 @@ class Matrix4 {
     _m4storage[7] = t8;
   }
 
-  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
+  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z as [double]s.
+  ///
+  /// If you know the argument types in a call site, prefer [scaleByDouble],
+  /// [scaleByVector3], or [scaleByVector4] for performance.
   void scale(dynamic x, [double? y, double? z]) {
-    double sx;
-    double sy;
-    double sz;
-    final sw = x is Vector4 ? x.w : 1.0;
     if (x is Vector3) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
+      scaleByVector3(x);
     } else if (x is Vector4) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
+      scaleByVector4(x);
     } else if (x is double) {
-      sx = x;
-      sy = y ?? x;
-      sz = z ?? x;
+      scaleByDouble(x, y ?? x, z ?? x);
     } else {
       throw UnimplementedError();
     }
+  }
+
+  /// Scale this matrix.
+  void scaleByDouble(double sx, double sy, double sz) {
+    _m4storage[0] *= sx;
+    _m4storage[1] *= sx;
+    _m4storage[2] *= sx;
+    _m4storage[3] *= sx;
+    _m4storage[4] *= sy;
+    _m4storage[5] *= sy;
+    _m4storage[6] *= sy;
+    _m4storage[7] *= sy;
+    _m4storage[8] *= sz;
+    _m4storage[9] *= sz;
+    _m4storage[10] *= sz;
+    _m4storage[11] *= sz;
+  }
+
+  /// Scale this matrix.
+  void scaleByVector3(Vector3 v3) {
+    final sx = v3.x;
+    final sy = v3.y;
+    final sz = v3.z;
+    _m4storage[0] *= sx;
+    _m4storage[1] *= sx;
+    _m4storage[2] *= sx;
+    _m4storage[3] *= sx;
+    _m4storage[4] *= sy;
+    _m4storage[5] *= sy;
+    _m4storage[6] *= sy;
+    _m4storage[7] *= sy;
+    _m4storage[8] *= sz;
+    _m4storage[9] *= sz;
+    _m4storage[10] *= sz;
+    _m4storage[11] *= sz;
+  }
+
+  /// Scale this matrix.
+  void scaleByVector4(Vector4 v4) {
+    final sx = v4.x;
+    final sy = v4.y;
+    final sz = v4.z;
+    final sw = v4.w;
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -1023,6 +1059,8 @@ class Matrix4 {
 
   /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
   /// [z].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
 
   /// Zeros this.

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -664,46 +664,18 @@ class Matrix4 {
   ///
   /// If you know the argument types in a call site, prefer [translateByDouble],
   /// [translateByVector3], or [translateByVector4] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final tw = x is Vector4 ? x.w : 1.0;
     if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      return translateByVector3(x);
     } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      return translateByVector4(x);
     } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
+      return translateByDouble(x, y, z);
     } else {
       throw UnimplementedError();
     }
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12] * tw;
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13] * tw;
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14] * tw;
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15] * tw;
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
-    _m4storage[15] = t4;
   }
 
   /// Translate this matrix by x, y, z.

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -661,6 +661,9 @@ class Matrix4 {
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
   /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
+  ///
+  /// If you know the argument types in a call site, prefer [translateByDouble],
+  /// [translateByVector3], or [translateByVector4] for performance.
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
@@ -703,7 +706,8 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
-  void translateByDouble(double tx, [double ty = 0.0, double tz = 0.0]) {
+  /// Translate this matrix by x, y, z.
+  void translateByDouble(double tx, double ty, double tz) {
     final tw = 1.0;
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
@@ -727,6 +731,7 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
+  /// Translate this matrix by a [Vector3].
   void translateByVector3(Vector3 v3) {
     final tx = v3.x;
     final ty = v3.y;
@@ -754,6 +759,7 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
+  /// Translate this matrix by a [Vector4].
   void translateByVector4(Vector4 v4) {
     final tx = v4.x;
     final ty = v4.y;

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -682,76 +682,17 @@ class Matrix4 {
     } else if (x is Vector4) {
       translateByVector4(x);
     } else if (x is double) {
-      translateByDouble(x, y, z);
+      translateByDouble(x, y, z, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Translate this matrix by x, y, z.
-  void translateByDouble(double tx, double ty, double tz) {
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12];
-    _m4storage[12] = t1;
-
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13];
-    _m4storage[13] = t2;
-
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14];
-    _m4storage[14] = t3;
-
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15];
-    _m4storage[15] = t4;
-  }
-
-  /// Translate this matrix by a [Vector3].
-  void translateByVector3(Vector3 v3) {
-    final tx = v3.x;
-    final ty = v3.y;
-    final tz = v3.z;
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12];
-    _m4storage[12] = t1;
-
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13];
-    _m4storage[13] = t2;
-
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14];
-    _m4storage[14] = t3;
-
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15];
-    _m4storage[15] = t4;
-  }
-
-  /// Translate this matrix by a [Vector4].
-  void translateByVector4(Vector4 v4) {
-    final tx = v4.x;
-    final ty = v4.y;
-    final tz = v4.z;
-    final tw = v4.w;
-
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByDouble(double tx, double ty, double tz, double tw) {
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
@@ -777,6 +718,20 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
+  /// Translate this matrix by a [Vector3].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByVector3(Vector3 v3) =>
+      translateByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Translate this matrix by a [Vector4].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByVector4(Vector4 v4) =>
+      translateByDouble(v4.x, v4.y, v4.z, v4.w);
+
   /// Multiply this by a translation from the left.
   ///
   /// The translation can be specified with a [Vector3], [Vector4], or x, y, z
@@ -794,77 +749,17 @@ class Matrix4 {
     } else if (x is Vector4) {
       leftTranslateByVector4(x);
     } else if (x is double) {
-      leftTranslateByDouble(x, y, z);
+      leftTranslateByDouble(x, y, z, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Multiply this by a translation from the left.
-  void leftTranslateByDouble(double tx, double ty, double tz) {
-    // Column 1
-    final r1 = _m4storage[3];
-    _m4storage[0] += tx * r1;
-    _m4storage[1] += ty * r1;
-    _m4storage[2] += tz * r1;
-
-    // Column 2
-    final r2 = _m4storage[7];
-    _m4storage[4] += tx * r2;
-    _m4storage[5] += ty * r2;
-    _m4storage[6] += tz * r2;
-
-    // Column 3
-    final r3 = _m4storage[11];
-    _m4storage[8] += tx * r3;
-    _m4storage[9] += ty * r3;
-    _m4storage[10] += tz * r3;
-
-    // Column 4
-    final r4 = _m4storage[15];
-    _m4storage[12] += tx * r4;
-    _m4storage[13] += ty * r4;
-    _m4storage[14] += tz * r4;
-  }
-
-  /// Multiply this by a translation from the left.
-  void leftTranslateByVector3(Vector3 v3) {
-    final tx = v3.x;
-    final ty = v3.y;
-    final tz = v3.z;
-
-    // Column 1
-    final r1 = _m4storage[3];
-    _m4storage[0] += tx * r1;
-    _m4storage[1] += ty * r1;
-    _m4storage[2] += tz * r1;
-
-    // Column 2
-    final r2 = _m4storage[7];
-    _m4storage[4] += tx * r2;
-    _m4storage[5] += ty * r2;
-    _m4storage[6] += tz * r2;
-
-    // Column 3
-    final r3 = _m4storage[11];
-    _m4storage[8] += tx * r3;
-    _m4storage[9] += ty * r3;
-    _m4storage[10] += tz * r3;
-
-    // Column 4
-    final r4 = _m4storage[15];
-    _m4storage[12] += tx * r4;
-    _m4storage[13] += ty * r4;
-    _m4storage[14] += tz * r4;
-  }
-
-  /// Multiply this by a translation from the left.
-  void leftTranslateByVector4(Vector4 v4) {
-    final tx = v4.x;
-    final ty = v4.y;
-    final tz = v4.z;
-    final tw = v4.w;
-
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByDouble(double tx, double ty, double tz, double tw) {
     // Column 1
     final r1 = _m4storage[3];
     _m4storage[0] += tx * r1;
@@ -893,6 +788,20 @@ class Matrix4 {
     _m4storage[14] += tz * r4;
     _m4storage[15] = tw * r4;
   }
+
+  /// Multiply this by a translation from the left.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByVector3(Vector3 v3) =>
+      leftTranslateByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Multiply this by a translation from the left.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByVector4(Vector4 v4) =>
+      leftTranslateByDouble(v4.x, v4.y, v4.z, v4.w);
 
   /// Rotate this [angle] radians around [axis]
   void rotate(Vector3 axis, double angle) {

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -986,6 +986,8 @@ class Matrix4 {
   ///
   /// If you know the argument types in a call site, prefer [scaleByDouble],
   /// [scaleByVector3], or [scaleByVector4] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -694,21 +694,24 @@ class Matrix4 {
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12];
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13];
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14];
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15];
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 
@@ -721,21 +724,24 @@ class Matrix4 {
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12];
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13];
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14];
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15];
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 
@@ -745,25 +751,29 @@ class Matrix4 {
     final ty = v4.y;
     final tz = v4.z;
     final tw = v4.w;
+
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12] * tw;
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13] * tw;
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14] * tw;
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15] * tw;
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 

--- a/lib/src/vector_math/matrix4.dart
+++ b/lib/src/vector_math/matrix4.dart
@@ -646,20 +646,21 @@ class Matrix4 {
   /// [transformed], [transformed3], or [multiplied] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector4) {
+      value = transformed(arg);
+    } else if (arg is Vector3) {
+      value = transformed3(arg);
+    } else if (arg is Matrix4) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector4) {
-      return transformed(arg);
-    }
-    if (arg is Vector3) {
-      return transformed3(arg);
-    }
-    if (arg is Matrix4) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]
@@ -674,13 +675,14 @@ class Matrix4 {
   /// [translateByVector3], or [translateByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
-      return translateByVector3(x);
+      translateByVector3(x);
     } else if (x is Vector4) {
-      return translateByVector4(x);
+      translateByVector4(x);
     } else if (x is double) {
-      return translateByDouble(x, y, z);
+      translateByDouble(x, y, z);
     } else {
       throw UnimplementedError();
     }
@@ -775,6 +777,7 @@ class Matrix4 {
   /// [leftTranslateByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       leftTranslateByVector3(x);
@@ -988,6 +991,7 @@ class Matrix4 {
   /// [scaleByVector3], or [scaleByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);
@@ -1063,6 +1067,7 @@ class Matrix4 {
   /// [z].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
 
   /// Zeros this.

--- a/lib/src/vector_math/opengl.dart
+++ b/lib/src/vector_math/opengl.dart
@@ -278,7 +278,7 @@ Matrix4 makePlaneProjection(Vector3 planeNormal, Vector3 planePoint) {
 Matrix4 makePlaneReflection(Vector3 planeNormal, Vector3 planePoint) {
   final v = Vector4(planeNormal.storage[0], planeNormal.storage[1],
       planeNormal.storage[2], 0.0);
-  final outer = Matrix4.outer(v, v)..scale(2.0);
+  final outer = Matrix4.outer(v, v)..scaleByDouble(2.0, 2.0, 2.0, 1.0);
   var r = Matrix4.zero();
   r = r - outer;
   final scale = 2.0 * planePoint.dot(planeNormal);

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -215,6 +215,8 @@ class Matrix2 {
   }
 
   /// Returns a new vector or matrix by multiplying this with [arg].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   dynamic operator *(dynamic arg) {
     if (arg is double) {
       return scaled(arg);

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -219,17 +219,17 @@ class Matrix2 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector2) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Matrix2) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math_64/matrix2.dart
+++ b/lib/src/vector_math_64/matrix2.dart
@@ -217,17 +217,19 @@ class Matrix2 {
   /// Returns a new vector or matrix by multiplying this with [arg].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector2) {
+      value = transformed(arg);
+    } else if (arg is Matrix2) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector2) {
-      return transformed(arg);
-    }
-    if (arg is Matrix2) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -328,17 +328,19 @@ class Matrix3 {
   /// Returns a new vector or matrix by multiplying this with [arg].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector3) {
+      value = transformed(arg);
+    } else if (arg is Matrix3) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector3) {
-      return transformed(arg);
-    }
-    if (arg is Matrix3) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -326,6 +326,8 @@ class Matrix3 {
   }
 
   /// Returns a new vector or matrix by multiplying this with [arg].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   dynamic operator *(dynamic arg) {
     if (arg is double) {
       return scaled(arg);

--- a/lib/src/vector_math_64/matrix3.dart
+++ b/lib/src/vector_math_64/matrix3.dart
@@ -330,17 +330,17 @@ class Matrix3 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector3) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Matrix3) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -461,7 +461,7 @@ class Matrix4 {
   void setFromTranslationRotationScale(
       Vector3 translation, Quaternion rotation, Vector3 scale) {
     setFromTranslationRotation(translation, rotation);
-    this.scale(scale);
+    scaleByVector3(scale);
   }
 
   /// Sets the upper 2x2 of the matrix to be [arg].
@@ -642,7 +642,7 @@ class Matrix4 {
   /// [arg] should be a [double] (to scale), [Vector4] (to transform), [Vector3]
   /// (to transform), or [Matrix4] (to multiply).
   ///
-  /// If you know the argument type in a call site, prefer [scaled],
+  /// If you know the argument type in a call site, prefer [scaledByDouble],
   /// [transformed], [transformed3], or [multiplied] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
@@ -650,7 +650,7 @@ class Matrix4 {
   dynamic operator *(dynamic arg) {
     final Object result;
     if (arg is double) {
-      result = scaled(arg);
+      result = scaledByDouble(arg, arg, arg, 1.0);
     } else if (arg is Vector4) {
       result = transformed(arg);
     } else if (arg is Vector3) {
@@ -676,6 +676,8 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use translateByVector3, translateByVector4, '
+      'or translateByDouble instead')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       translateByVector3(x);
@@ -743,6 +745,8 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use leftTranslateByVector3, leftTranslateByVector4, '
+      'or leftTranslateByDouble instead')
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       leftTranslateByVector3(x);
@@ -923,59 +927,24 @@ class Matrix4 {
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use scaleByVector3, scaleByVector4, or scaleByDouble instead')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);
     } else if (x is Vector4) {
       scaleByVector4(x);
     } else if (x is double) {
-      scaleByDouble(x, y ?? x, z ?? x);
+      scaleByDouble(x, y ?? x, z ?? x, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Scale this matrix.
-  void scaleByDouble(double sx, double sy, double sz) {
-    _m4storage[0] *= sx;
-    _m4storage[1] *= sx;
-    _m4storage[2] *= sx;
-    _m4storage[3] *= sx;
-    _m4storage[4] *= sy;
-    _m4storage[5] *= sy;
-    _m4storage[6] *= sy;
-    _m4storage[7] *= sy;
-    _m4storage[8] *= sz;
-    _m4storage[9] *= sz;
-    _m4storage[10] *= sz;
-    _m4storage[11] *= sz;
-  }
-
-  /// Scale this matrix.
-  void scaleByVector3(Vector3 v3) {
-    final sx = v3.x;
-    final sy = v3.y;
-    final sz = v3.z;
-    _m4storage[0] *= sx;
-    _m4storage[1] *= sx;
-    _m4storage[2] *= sx;
-    _m4storage[3] *= sx;
-    _m4storage[4] *= sy;
-    _m4storage[5] *= sy;
-    _m4storage[6] *= sy;
-    _m4storage[7] *= sy;
-    _m4storage[8] *= sz;
-    _m4storage[9] *= sz;
-    _m4storage[10] *= sz;
-    _m4storage[11] *= sz;
-  }
-
-  /// Scale this matrix.
-  void scaleByVector4(Vector4 v4) {
-    final sx = v4.x;
-    final sy = v4.y;
-    final sz = v4.z;
-    final sw = v4.w;
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByDouble(double sx, double sy, double sz, double sw) {
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -994,12 +963,44 @@ class Matrix4 {
     _m4storage[15] *= sw;
   }
 
+  /// Scale this matrix.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByVector3(Vector3 v3) => scaleByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Scale this matrix.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void scaleByVector4(Vector4 v4) => scaleByDouble(v4.x, v4.y, v4.z, v4.w);
+
   /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
   /// [z].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
+  @Deprecated('Use scaledByVector3, scaledByVector4, or scaledByDouble instead')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
+
+  /// Create a copy of this scaled by [x], [y], [z], and [t].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByDouble(double x, double y, double z, double t) =>
+      clone()..scaleByDouble(x, y, z, t);
+
+  /// Create a copy of this scaled by a [Vector3].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByVector3(Vector3 v3) => clone()..scaleByVector3(v3);
+
+  /// Create a copy of this scaled by a [Vector4].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  Matrix4 scaledByVector4(Vector4 v4) => clone()..scaleByVector4(v4);
 
   /// Zeros this.
   void setZero() {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -648,19 +648,19 @@ class Matrix4 {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
-    final dynamic value;
+    final Object result;
     if (arg is double) {
-      value = scaled(arg);
+      result = scaled(arg);
     } else if (arg is Vector4) {
-      value = transformed(arg);
+      result = transformed(arg);
     } else if (arg is Vector3) {
-      value = transformed3(arg);
+      result = transformed3(arg);
     } else if (arg is Matrix4) {
-      value = multiplied(arg);
+      result = multiplied(arg);
     } else {
       throw ArgumentError(arg);
     }
-    return value;
+    return result;
   }
 
   /// Returns new matrix after component wise this + [arg]

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -787,7 +787,6 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
-
   /// Multiply this by a translation from the left.
   /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -690,7 +690,7 @@ class Matrix4 {
     }
   }
 
-  /// Translate this matrix by x, y, z.
+  /// Translate this matrix by x, y, z, w.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
   @pragma('dart2js:prefer-inline')

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -803,24 +803,28 @@ class Matrix4 {
   /// Multiply this by a translation from the left.
   void leftTranslateByDouble(double tx, double ty, double tz) {
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
   }
 
   /// Multiply this by a translation from the left.
@@ -830,24 +834,28 @@ class Matrix4 {
     final tz = v3.z;
 
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
   }
 
   /// Multiply this by a translation from the left.
@@ -858,28 +866,32 @@ class Matrix4 {
     final tw = v4.w;
 
     // Column 1
-    _m4storage[0] += tx * _m4storage[3];
-    _m4storage[1] += ty * _m4storage[3];
-    _m4storage[2] += tz * _m4storage[3];
-    _m4storage[3] = tw * _m4storage[3];
+    final r1 = _m4storage[3];
+    _m4storage[0] += tx * r1;
+    _m4storage[1] += ty * r1;
+    _m4storage[2] += tz * r1;
+    _m4storage[3] = tw * r1;
 
     // Column 2
-    _m4storage[4] += tx * _m4storage[7];
-    _m4storage[5] += ty * _m4storage[7];
-    _m4storage[6] += tz * _m4storage[7];
-    _m4storage[7] = tw * _m4storage[7];
+    final r2 = _m4storage[7];
+    _m4storage[4] += tx * r2;
+    _m4storage[5] += ty * r2;
+    _m4storage[6] += tz * r2;
+    _m4storage[7] = tw * r2;
 
     // Column 3
-    _m4storage[8] += tx * _m4storage[11];
-    _m4storage[9] += ty * _m4storage[11];
-    _m4storage[10] += tz * _m4storage[11];
-    _m4storage[11] = tw * _m4storage[11];
+    final r3 = _m4storage[11];
+    _m4storage[8] += tx * r3;
+    _m4storage[9] += ty * r3;
+    _m4storage[10] += tz * r3;
+    _m4storage[11] = tw * r3;
 
     // Column 4
-    _m4storage[12] += tx * _m4storage[15];
-    _m4storage[13] += ty * _m4storage[15];
-    _m4storage[14] += tz * _m4storage[15];
-    _m4storage[15] = tw * _m4storage[15];
+    final r4 = _m4storage[15];
+    _m4storage[12] += tx * r4;
+    _m4storage[13] += ty * r4;
+    _m4storage[14] += tz * r4;
+    _m4storage[15] = tw * r4;
   }
 
   /// Rotate this [angle] radians around [axis]

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -982,27 +982,63 @@ class Matrix4 {
     _m4storage[7] = t8;
   }
 
-  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
+  /// Scale this matrix by a [Vector3], [Vector4], or x,y,z as [double]s.
+  ///
+  /// If you know the argument types in a call site, prefer [scaleByDouble],
+  /// [scaleByVector3], or [scaleByVector4] for performance.
   void scale(dynamic x, [double? y, double? z]) {
-    double sx;
-    double sy;
-    double sz;
-    final sw = x is Vector4 ? x.w : 1.0;
     if (x is Vector3) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
+      scaleByVector3(x);
     } else if (x is Vector4) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
+      scaleByVector4(x);
     } else if (x is double) {
-      sx = x;
-      sy = y ?? x;
-      sz = z ?? x;
+      scaleByDouble(x, y ?? x, z ?? x);
     } else {
       throw UnimplementedError();
     }
+  }
+
+  /// Scale this matrix.
+  void scaleByDouble(double sx, double sy, double sz) {
+    _m4storage[0] *= sx;
+    _m4storage[1] *= sx;
+    _m4storage[2] *= sx;
+    _m4storage[3] *= sx;
+    _m4storage[4] *= sy;
+    _m4storage[5] *= sy;
+    _m4storage[6] *= sy;
+    _m4storage[7] *= sy;
+    _m4storage[8] *= sz;
+    _m4storage[9] *= sz;
+    _m4storage[10] *= sz;
+    _m4storage[11] *= sz;
+  }
+
+  /// Scale this matrix.
+  void scaleByVector3(Vector3 v3) {
+    final sx = v3.x;
+    final sy = v3.y;
+    final sz = v3.z;
+    _m4storage[0] *= sx;
+    _m4storage[1] *= sx;
+    _m4storage[2] *= sx;
+    _m4storage[3] *= sx;
+    _m4storage[4] *= sy;
+    _m4storage[5] *= sy;
+    _m4storage[6] *= sy;
+    _m4storage[7] *= sy;
+    _m4storage[8] *= sz;
+    _m4storage[9] *= sz;
+    _m4storage[10] *= sz;
+    _m4storage[11] *= sz;
+  }
+
+  /// Scale this matrix.
+  void scaleByVector4(Vector4 v4) {
+    final sx = v4.x;
+    final sy = v4.y;
+    final sz = v4.z;
+    final sw = v4.w;
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -1023,6 +1059,8 @@ class Matrix4 {
 
   /// Create a copy of this scaled by a [Vector3], [Vector4] or [x],[y], and
   /// [z].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
 
   /// Zeros this.

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -661,6 +661,9 @@ class Matrix4 {
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
   /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
+  ///
+  /// If you know the argument types in a call site, prefer [translateByDouble],
+  /// [translateByVector3], or [translateByVector4] for performance.
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     double tx;
     double ty;
@@ -702,6 +705,88 @@ class Matrix4 {
     _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
+
+  /// Translate this matrix by x, y, z.
+  void translateByDouble(double tx, double ty, double tz) {
+    final tw = 1.0;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
+  /// Translate this matrix by a [Vector3].
+  void translateByVector3(Vector3 v3) {
+    final tx = v3.x;
+    final ty = v3.y;
+    final tz = v3.z;
+    final tw = 1.0;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
+  /// Translate this matrix by a [Vector4].
+  void translateByVector4(Vector4 v4) {
+    final tx = v4.x;
+    final ty = v4.y;
+    final tz = v4.z;
+    final tw = v4.w;
+    final t1 = _m4storage[0] * tx +
+        _m4storage[4] * ty +
+        _m4storage[8] * tz +
+        _m4storage[12] * tw;
+    final t2 = _m4storage[1] * tx +
+        _m4storage[5] * ty +
+        _m4storage[9] * tz +
+        _m4storage[13] * tw;
+    final t3 = _m4storage[2] * tx +
+        _m4storage[6] * ty +
+        _m4storage[10] * tz +
+        _m4storage[14] * tw;
+    final t4 = _m4storage[3] * tx +
+        _m4storage[7] * ty +
+        _m4storage[11] * tz +
+        _m4storage[15] * tw;
+    _m4storage[12] = t1;
+    _m4storage[13] = t2;
+    _m4storage[14] = t3;
+    _m4storage[15] = t4;
+  }
+
 
   /// Multiply this by a translation from the left.
   /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -682,76 +682,17 @@ class Matrix4 {
     } else if (x is Vector4) {
       translateByVector4(x);
     } else if (x is double) {
-      translateByDouble(x, y, z);
+      translateByDouble(x, y, z, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Translate this matrix by x, y, z.
-  void translateByDouble(double tx, double ty, double tz) {
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12];
-    _m4storage[12] = t1;
-
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13];
-    _m4storage[13] = t2;
-
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14];
-    _m4storage[14] = t3;
-
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15];
-    _m4storage[15] = t4;
-  }
-
-  /// Translate this matrix by a [Vector3].
-  void translateByVector3(Vector3 v3) {
-    final tx = v3.x;
-    final ty = v3.y;
-    final tz = v3.z;
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12];
-    _m4storage[12] = t1;
-
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13];
-    _m4storage[13] = t2;
-
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14];
-    _m4storage[14] = t3;
-
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15];
-    _m4storage[15] = t4;
-  }
-
-  /// Translate this matrix by a [Vector4].
-  void translateByVector4(Vector4 v4) {
-    final tx = v4.x;
-    final ty = v4.y;
-    final tz = v4.z;
-    final tw = v4.w;
-
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByDouble(double tx, double ty, double tz, double tw) {
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
@@ -777,6 +718,20 @@ class Matrix4 {
     _m4storage[15] = t4;
   }
 
+  /// Translate this matrix by a [Vector3].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByVector3(Vector3 v3) =>
+      translateByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Translate this matrix by a [Vector4].
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void translateByVector4(Vector4 v4) =>
+      translateByDouble(v4.x, v4.y, v4.z, v4.w);
+
   /// Multiply this by a translation from the left.
   ///
   /// The translation can be specified with a [Vector3], [Vector4], or x, y, z
@@ -794,77 +749,17 @@ class Matrix4 {
     } else if (x is Vector4) {
       leftTranslateByVector4(x);
     } else if (x is double) {
-      leftTranslateByDouble(x, y, z);
+      leftTranslateByDouble(x, y, z, 1.0);
     } else {
       throw UnimplementedError();
     }
   }
 
   /// Multiply this by a translation from the left.
-  void leftTranslateByDouble(double tx, double ty, double tz) {
-    // Column 1
-    final r1 = _m4storage[3];
-    _m4storage[0] += tx * r1;
-    _m4storage[1] += ty * r1;
-    _m4storage[2] += tz * r1;
-
-    // Column 2
-    final r2 = _m4storage[7];
-    _m4storage[4] += tx * r2;
-    _m4storage[5] += ty * r2;
-    _m4storage[6] += tz * r2;
-
-    // Column 3
-    final r3 = _m4storage[11];
-    _m4storage[8] += tx * r3;
-    _m4storage[9] += ty * r3;
-    _m4storage[10] += tz * r3;
-
-    // Column 4
-    final r4 = _m4storage[15];
-    _m4storage[12] += tx * r4;
-    _m4storage[13] += ty * r4;
-    _m4storage[14] += tz * r4;
-  }
-
-  /// Multiply this by a translation from the left.
-  void leftTranslateByVector3(Vector3 v3) {
-    final tx = v3.x;
-    final ty = v3.y;
-    final tz = v3.z;
-
-    // Column 1
-    final r1 = _m4storage[3];
-    _m4storage[0] += tx * r1;
-    _m4storage[1] += ty * r1;
-    _m4storage[2] += tz * r1;
-
-    // Column 2
-    final r2 = _m4storage[7];
-    _m4storage[4] += tx * r2;
-    _m4storage[5] += ty * r2;
-    _m4storage[6] += tz * r2;
-
-    // Column 3
-    final r3 = _m4storage[11];
-    _m4storage[8] += tx * r3;
-    _m4storage[9] += ty * r3;
-    _m4storage[10] += tz * r3;
-
-    // Column 4
-    final r4 = _m4storage[15];
-    _m4storage[12] += tx * r4;
-    _m4storage[13] += ty * r4;
-    _m4storage[14] += tz * r4;
-  }
-
-  /// Multiply this by a translation from the left.
-  void leftTranslateByVector4(Vector4 v4) {
-    final tx = v4.x;
-    final ty = v4.y;
-    final tz = v4.z;
-    final tw = v4.w;
-
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByDouble(double tx, double ty, double tz, double tw) {
     // Column 1
     final r1 = _m4storage[3];
     _m4storage[0] += tx * r1;
@@ -893,6 +788,20 @@ class Matrix4 {
     _m4storage[14] += tz * r4;
     _m4storage[15] = tw * r4;
   }
+
+  /// Multiply this by a translation from the left.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByVector3(Vector3 v3) =>
+      leftTranslateByDouble(v3.x, v3.y, v3.z, 1.0);
+
+  /// Multiply this by a translation from the left.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
+  void leftTranslateByVector4(Vector4 v4) =>
+      leftTranslateByDouble(v4.x, v4.y, v4.z, v4.w);
 
   /// Rotate this [angle] radians around [axis]
   void rotate(Vector3 axis, double angle) {

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -986,6 +986,8 @@ class Matrix4 {
   ///
   /// If you know the argument types in a call site, prefer [scaleByDouble],
   /// [scaleByVector3], or [scaleByVector4] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -694,21 +694,24 @@ class Matrix4 {
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12];
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13];
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14];
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15];
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 
@@ -721,21 +724,24 @@ class Matrix4 {
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12];
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13];
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14];
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15];
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 
@@ -745,25 +751,29 @@ class Matrix4 {
     final ty = v4.y;
     final tz = v4.z;
     final tw = v4.w;
+
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
         _m4storage[12] * tw;
+    _m4storage[12] = t1;
+
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
         _m4storage[13] * tw;
+    _m4storage[13] = t2;
+
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
         _m4storage[14] * tw;
+    _m4storage[14] = t3;
+
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
         _m4storage[15] * tw;
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
     _m4storage[15] = t4;
   }
 

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -638,6 +638,14 @@ class Matrix4 {
   Matrix4 operator -() => clone()..negate();
 
   /// Returns a new vector or matrix by multiplying this with [arg].
+  ///
+  /// [arg] should be a [double] (to scale), [Vector4] (to transform), [Vector3]
+  /// (to transform), or [Matrix4] (to multiply).
+  ///
+  /// If you know the argument type in a call site, prefer [scaled],
+  /// [transformed], [transformed3], or [multiplied] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   dynamic operator *(dynamic arg) {
     if (arg is double) {
       return scaled(arg);
@@ -660,71 +668,42 @@ class Matrix4 {
   /// Returns new matrix after component wise this - [arg]
   Matrix4 operator -(Matrix4 arg) => clone()..sub(arg);
 
-  /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
+  /// Translate this matrix by a [Vector3], [Vector4], or x,y,z as [double]s.
   ///
   /// If you know the argument types in a call site, prefer [translateByDouble],
   /// [translateByVector3], or [translateByVector4] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final tw = x is Vector4 ? x.w : 1.0;
     if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      return translateByVector3(x);
     } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      return translateByVector4(x);
     } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
+      return translateByDouble(x, y, z);
     } else {
       throw UnimplementedError();
     }
-    final t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
-        _m4storage[12] * tw;
-    final t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
-        _m4storage[13] * tw;
-    final t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
-        _m4storage[14] * tw;
-    final t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
-        _m4storage[15] * tw;
-    _m4storage[12] = t1;
-    _m4storage[13] = t2;
-    _m4storage[14] = t3;
-    _m4storage[15] = t4;
   }
 
   /// Translate this matrix by x, y, z.
   void translateByDouble(double tx, double ty, double tz) {
-    final tw = 1.0;
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
-        _m4storage[12] * tw;
+        _m4storage[12];
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
-        _m4storage[13] * tw;
+        _m4storage[13];
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
-        _m4storage[14] * tw;
+        _m4storage[14];
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
-        _m4storage[15] * tw;
+        _m4storage[15];
     _m4storage[12] = t1;
     _m4storage[13] = t2;
     _m4storage[14] = t3;
@@ -736,23 +715,22 @@ class Matrix4 {
     final tx = v3.x;
     final ty = v3.y;
     final tz = v3.z;
-    final tw = 1.0;
     final t1 = _m4storage[0] * tx +
         _m4storage[4] * ty +
         _m4storage[8] * tz +
-        _m4storage[12] * tw;
+        _m4storage[12];
     final t2 = _m4storage[1] * tx +
         _m4storage[5] * ty +
         _m4storage[9] * tz +
-        _m4storage[13] * tw;
+        _m4storage[13];
     final t3 = _m4storage[2] * tx +
         _m4storage[6] * ty +
         _m4storage[10] * tz +
-        _m4storage[14] * tw;
+        _m4storage[14];
     final t4 = _m4storage[3] * tx +
         _m4storage[7] * ty +
         _m4storage[11] * tz +
-        _m4storage[15] * tw;
+        _m4storage[15];
     _m4storage[12] = t1;
     _m4storage[13] = t2;
     _m4storage[14] = t3;
@@ -788,27 +766,83 @@ class Matrix4 {
   }
 
   /// Multiply this by a translation from the left.
-  /// The translation can be specified with a  [Vector3], [Vector4], or x, y, z.
+  ///
+  /// The translation can be specified with a [Vector3], [Vector4], or x, y, z
+  /// as [double]s.
+  ///
+  /// If you know the argument types in a call site, prefer
+  /// [leftTranslateByDouble], [leftTranslateByVector3], or
+  /// [leftTranslateByVector4] for performance.
+  @pragma('wasm:prefer-inline')
+  @pragma('vm:prefer-inline')
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
-    final tw = x is Vector4 ? x.w : 1.0;
     if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      leftTranslateByVector3(x);
     } else if (x is Vector4) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
+      leftTranslateByVector4(x);
     } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
+      leftTranslateByDouble(x, y, z);
     } else {
       throw UnimplementedError();
     }
+  }
+
+  /// Multiply this by a translation from the left.
+  void leftTranslateByDouble(double tx, double ty, double tz) {
+    // Column 1
+    _m4storage[0] += tx * _m4storage[3];
+    _m4storage[1] += ty * _m4storage[3];
+    _m4storage[2] += tz * _m4storage[3];
+
+    // Column 2
+    _m4storage[4] += tx * _m4storage[7];
+    _m4storage[5] += ty * _m4storage[7];
+    _m4storage[6] += tz * _m4storage[7];
+
+    // Column 3
+    _m4storage[8] += tx * _m4storage[11];
+    _m4storage[9] += ty * _m4storage[11];
+    _m4storage[10] += tz * _m4storage[11];
+
+    // Column 4
+    _m4storage[12] += tx * _m4storage[15];
+    _m4storage[13] += ty * _m4storage[15];
+    _m4storage[14] += tz * _m4storage[15];
+  }
+
+  /// Multiply this by a translation from the left.
+  void leftTranslateByVector3(Vector3 v3) {
+    final tx = v3.x;
+    final ty = v3.y;
+    final tz = v3.z;
+
+    // Column 1
+    _m4storage[0] += tx * _m4storage[3];
+    _m4storage[1] += ty * _m4storage[3];
+    _m4storage[2] += tz * _m4storage[3];
+
+    // Column 2
+    _m4storage[4] += tx * _m4storage[7];
+    _m4storage[5] += ty * _m4storage[7];
+    _m4storage[6] += tz * _m4storage[7];
+
+    // Column 3
+    _m4storage[8] += tx * _m4storage[11];
+    _m4storage[9] += ty * _m4storage[11];
+    _m4storage[10] += tz * _m4storage[11];
+
+    // Column 4
+    _m4storage[12] += tx * _m4storage[15];
+    _m4storage[13] += ty * _m4storage[15];
+    _m4storage[14] += tz * _m4storage[15];
+  }
+
+  /// Multiply this by a translation from the left.
+  void leftTranslateByVector4(Vector4 v4) {
+    final tx = v4.x;
+    final ty = v4.y;
+    final tz = v4.z;
+    final tw = v4.w;
 
     // Column 1
     _m4storage[0] += tx * _m4storage[3];

--- a/lib/src/vector_math_64/matrix4.dart
+++ b/lib/src/vector_math_64/matrix4.dart
@@ -646,20 +646,21 @@ class Matrix4 {
   /// [transformed], [transformed3], or [multiplied] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   dynamic operator *(dynamic arg) {
+    final dynamic value;
     if (arg is double) {
-      return scaled(arg);
+      value = scaled(arg);
+    } else if (arg is Vector4) {
+      value = transformed(arg);
+    } else if (arg is Vector3) {
+      value = transformed3(arg);
+    } else if (arg is Matrix4) {
+      value = multiplied(arg);
+    } else {
+      throw ArgumentError(arg);
     }
-    if (arg is Vector4) {
-      return transformed(arg);
-    }
-    if (arg is Vector3) {
-      return transformed3(arg);
-    }
-    if (arg is Matrix4) {
-      return multiplied(arg);
-    }
-    throw ArgumentError(arg);
+    return value;
   }
 
   /// Returns new matrix after component wise this + [arg]
@@ -674,13 +675,14 @@ class Matrix4 {
   /// [translateByVector3], or [translateByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
-      return translateByVector3(x);
+      translateByVector3(x);
     } else if (x is Vector4) {
-      return translateByVector4(x);
+      translateByVector4(x);
     } else if (x is double) {
-      return translateByDouble(x, y, z);
+      translateByDouble(x, y, z);
     } else {
       throw UnimplementedError();
     }
@@ -775,6 +777,7 @@ class Matrix4 {
   /// [leftTranslateByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void leftTranslate(dynamic x, [double y = 0.0, double z = 0.0]) {
     if (x is Vector3) {
       leftTranslateByVector3(x);
@@ -988,6 +991,7 @@ class Matrix4 {
   /// [scaleByVector3], or [scaleByVector4] for performance.
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   void scale(dynamic x, [double? y, double? z]) {
     if (x is Vector3) {
       scaleByVector3(x);
@@ -1063,6 +1067,7 @@ class Matrix4 {
   /// [z].
   @pragma('wasm:prefer-inline')
   @pragma('vm:prefer-inline')
+  @pragma('dart2js:prefer-inline')
   Matrix4 scaled(dynamic x, [double? y, double? z]) => clone()..scale(x, y, z);
 
   /// Zeros this.

--- a/lib/src/vector_math_64/opengl.dart
+++ b/lib/src/vector_math_64/opengl.dart
@@ -278,7 +278,7 @@ Matrix4 makePlaneProjection(Vector3 planeNormal, Vector3 planePoint) {
 Matrix4 makePlaneReflection(Vector3 planeNormal, Vector3 planePoint) {
   final v = Vector4(planeNormal.storage[0], planeNormal.storage[1],
       planeNormal.storage[2], 0.0);
-  final outer = Matrix4.outer(v, v)..scale(2.0);
+  final outer = Matrix4.outer(v, v)..scaleByDouble(2.0, 2.0, 2.0, 1.0);
   var r = Matrix4.zero();
   r = r - outer;
   final scale = 2.0 * planePoint.dot(planeNormal);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.2.0-wip
+version: 3.0.0-wip
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 2.1.5
+version: 2.2.0-wip
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: vector_math
-version: 3.0.0-wip
+version: 2.2.0-wip
 description: A Vector Math library for 2D and 3D applications.
 repository: https://github.com/google/vector_math.dart
 

--- a/test/geometry_test.dart
+++ b/test/geometry_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:typed_data';
 
 import 'package:test/test.dart';

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -385,7 +385,7 @@ void testMatrix4Translation() {
   output3[14] = input.dotRow(2, Vector4(4, 8, 12, 1));
   output3[15] = input.dotRow(3, Vector4(4, 8, 12, 1));
   relativeTest(
-    input.clone()..translateByDouble(4.0, 8.0, 12.0),
+    input.clone()..translateByDouble(4.0, 8.0, 12.0, 1.0),
     output3,
   );
   relativeTest(

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:math' as math;
 import 'dart:typed_data';
 

--- a/test/matrix4_test.dart
+++ b/test/matrix4_test.dart
@@ -372,6 +372,36 @@ void testMatrix4Translation() {
   for (var i = 0; i < inputA.length; i++) {
     relativeTest(output1[i], output2[i]);
   }
+
+  final input = Matrix4.fromList([
+    1, 5, 9, 13, //
+    2, 6, 10, 14, //
+    3, 7, 11, 15, //
+    4, 8, 12, 16, //
+  ]);
+  final output3 = input.clone();
+  output3[12] = input.dotRow(0, Vector4(4, 8, 12, 1));
+  output3[13] = input.dotRow(1, Vector4(4, 8, 12, 1));
+  output3[14] = input.dotRow(2, Vector4(4, 8, 12, 1));
+  output3[15] = input.dotRow(3, Vector4(4, 8, 12, 1));
+  relativeTest(
+    input.clone()..translateByDouble(4.0, 8.0, 12.0),
+    output3,
+  );
+  relativeTest(
+    input.clone()..translateByVector3(Vector3(4.0, 8.0, 12.0)),
+    output3,
+  );
+
+  final output4 = input.clone();
+  output4[12] = input.dotRow(0, Vector4(4, 8, 12, 16));
+  output4[13] = input.dotRow(1, Vector4(4, 8, 12, 16));
+  output4[14] = input.dotRow(2, Vector4(4, 8, 12, 16));
+  output4[15] = input.dotRow(3, Vector4(4, 8, 12, 16));
+  relativeTest(
+    input.clone()..translateByVector4(Vector4(4, 8, 12, 16)),
+    output4,
+  );
 }
 
 void testMatrix4Scale() {


### PR DESCRIPTION
`Matrix4.translate` is used by Flutter and it often appears as an overhead when
profiling Flutter apps compiled to Wasm.

![matrix4_translate_prof](https://github.com/user-attachments/assets/546c09f0-2c09-437f-9cb8-c4bbc20117d3)

The function currently takes a `dynamic` argument and takes different code
paths based on the type.

This is inefficient when the call site already knows the argument's type.

In general, when we have a performance-critical generic function that checks
types of the arguments, it makes sense to introduce specialized versions of the
function based on precise argument types that it handles, so that callers can
call the more efficient specialized versions and avoid the type test overheads.

For each function with `dynamic` argument, this PR introduces specialized
functions based on precise argument types that the functions handle, call those
specialized functions from the `dynamic` functions, and then inline the
`dynamic` functions.

This allows compilers to eliminate the type tests when the types are known in a
call site, and call the efficient functions directly.

For example, for `Vector4.translate`, we introduce:

- `Vector4.translateByDouble(double x, double y, double z)`
- `Vector4.translateByVector3(Vector3 v3)`
- `Vector4.translateByVector4(Vector4 v4)`

Call sites that know the argument type can directly call these for performance.

Existing call sites will be automatically improved when updating the library,
as the type-testing functions will be inlined and type tests will be eliminated
in most (probably all cases).

dart2wasm benchmarks: (`-O2`)

```
// Before
Matrix4.translateByDoubleGeneric(RunTime): 8.032 us.
Matrix4.translateByVector3Generic(RunTime): 8.457468284493933 us.
Matrix4.translateByVector4Generic(RunTime): 9.094468169361408 us.

// After
Matrix4.translateByDoubleGeneric(RunTime): 4.86 us.
Matrix4.translateByVector3Generic(RunTime): 4.796994003757495 us.
Matrix4.translateByVector4Generic(RunTime): 4.795 us.
Matrix4.translateByDouble(RunTime): 4.8425 us.
Matrix4.translateByVector3(RunTime): 4.997243753445308 us.
Matrix4.translateByVector4(RunTime): 4.909493863132671 us.
```

dart2js benchmarks: (`-O4`)

```
// Before
Matrix4.translateByDoubleGeneric(RunTime): 6.224801171860612 us.
Matrix4.translateByVector3Generic(RunTime): 9.400219449286789 us.
Matrix4.translateByVector4Generic(RunTime): 10.751954304194207 us.

// After
Matrix4.translateByDoubleGeneric(RunTime): 4.21 us.
Matrix4.translateByVector3Generic(RunTime): 4.388117869308463 us.
Matrix4.translateByVector4Generic(RunTime): 4.9375 us.
Matrix4.translateByDouble(RunTime): 4.1782447771940285 us.
Matrix4.translateByVector3(RunTime): 4.436994453756933 us.
Matrix4.translateByVector4(RunTime): 5.0375 us.
```

AOT benchmarks:

```
// Before
Matrix4.translateByDoubleGeneric(RunTime): 6.5326339347321305 us.
Matrix4.translateByVector3Generic(RunTime): 6.445286109427781 us.
Matrix4.translateByVector4Generic(RunTime): 6.807083684061711 us.

// After
Matrix4.translateByDoubleGeneric(RunTime): 4.193214 us.
Matrix4.translateByVector3Generic(RunTime): 4.132444 us.
Matrix4.translateByVector4Generic(RunTime): 4.821352357295285 us.
Matrix4.translateByDouble(RunTime): 4.074234 us.
Matrix4.translateByVector3(RunTime): 4.061202 us.
Matrix4.translateByVector4(RunTime): 4.735463330670837 us.
```

JIT benchmarks:

```
// Before
Matrix4.translateByDoubleGeneric(RunTime): 4.189242 us.
Matrix4.translateByVector3Generic(RunTime): 8.532402136592522 us.
Matrix4.translateByVector4Generic(RunTime): 7.937426969102983 us.

// After
Matrix4.translateByDoubleGeneric(RunTime): 4.029674 us.
Matrix4.translateByVector3Generic(RunTime): 4.037351666666667 us.
Matrix4.translateByVector4Generic(RunTime): 4.901740372824534 us.
Matrix4.translateByDouble(RunTime): 4.247654940431325 us.
Matrix4.translateByVector3(RunTime): 4.058694 us.
Matrix4.translateByVector4(RunTime): 4.831515710605362 us.
```

Performance or other improved functions `scale`, `scaled`, `operator *`, and
`leftTranslate` should be improved similarly.